### PR TITLE
Fixed: 跨平台使用时help命令无法发出

### DIFF
--- a/nonebot_plugin_maimaidx/__init__.py
+++ b/nonebot_plugin_maimaidx/__init__.py
@@ -145,7 +145,9 @@ async def _(event: PrivateMessageEvent):
 
 @manual.handle()
 async def _():
-    await manual.finish(MessageSegment.image(f'file:///{Root / "maimaidxhelp.png"}'), reply_message=True)
+    with open(f'{Root}/maimaidxhelp.png', 'rb') as f:
+        help_image = f.read()
+        await manual.finish(MessageSegment.image(help_image), reply_message=True)
 
 
 @repo.handle()

--- a/nonebot_plugin_maimaidx/__init__.py
+++ b/nonebot_plugin_maimaidx/__init__.py
@@ -7,6 +7,7 @@ from string import ascii_uppercase, digits
 from textwrap import dedent
 from typing import Optional, Tuple
 
+import aiofiles
 import nonebot
 from nonebot import get_bot, on_command, on_endswith, on_message, on_regex, require
 from nonebot.adapters.onebot.v11 import (
@@ -145,9 +146,9 @@ async def _(event: PrivateMessageEvent):
 
 @manual.handle()
 async def _():
-    with open(f'{Root}/maimaidxhelp.png', 'rb') as f:
-        help_image = f.read()
-        await manual.finish(MessageSegment.image(help_image), reply_message=True)
+    async with aiofiles.open(Root / 'maimaidxhelp.png', 'rb') as f:
+        help_image = await f.read()
+    await manual.finish(MessageSegment.image(help_image), reply_message=True)
 
 
 @repo.handle()


### PR DESCRIPTION
当Bot主程序与Nonebot客户端不在一个设备上时，Bot主程序会因为无法读取到File URI所对应的文件时而无法发出help图片，因此需要改用Nonebot内读取图片并发送