### PR TITLE
修复跨系统连接Bot无法发送定数表的问题

### DIFF
--- a/nonebot_plugin_maimaidx/__init__.py
+++ b/nonebot_plugin_maimaidx/__init__.py
@@ -733,7 +733,9 @@ async def _(match: Tuple = RegexGroup()):
             img = ratingdir / '14.png'
         else:
             img = ratingdir / f'{args}.png'
-        await rating_table.send(MessageSegment.image(f'''file:///{img}'''))
+        async with aiofiles.open(img, 'rb') as f:
+            rating_table_img = await f.read()
+        await rating_table.send(MessageSegment.image(rating_table_img))
     else:
         await rating_table.send('无法识别的定数', reply_message=True)
 

--- a/nonebot_plugin_maimaidx/__init__.py
+++ b/nonebot_plugin_maimaidx/__init__.py
@@ -29,7 +29,7 @@ from .libraries.maimaidx_best_50 import *
 from .libraries.maimaidx_music import alias, guess, mai, update_local_alias
 from .libraries.maimaidx_music_info import *
 from .libraries.maimaidx_player_score import *
-from .libraries.tool import hash
+from .libraries.tool import hash, read_image
 
 __plugin_meta__ = PluginMetadata(
     name='nonebot-plugin-maimaidx',
@@ -143,9 +143,7 @@ async def _(event: PrivateMessageEvent):
 
 @manual.handle()
 async def _():
-    async with aiofiles.open(Root / 'maimaidxhelp.png', 'rb') as f:
-        help_image = await f.read()
-    await manual.finish(MessageSegment.image(help_image), reply_message=True)
+    await manual.finish(MessageSegment.image(await read_image(Root / 'maimaidxhelp.png')), reply_message=True)
 
 
 @repo.handle()
@@ -733,9 +731,7 @@ async def _(match: Tuple = RegexGroup()):
             img = ratingdir / '14.png'
         else:
             img = ratingdir / f'{args}.png'
-        async with aiofiles.open(img, 'rb') as f:
-            rating_table_img = await f.read()
-        await rating_table.send(MessageSegment.image(rating_table_img))
+        await rating_table.send(MessageSegment.image(await read_image(img)))
     else:
         await rating_table.send('无法识别的定数', reply_message=True)
 

--- a/nonebot_plugin_maimaidx/libraries/tool.py
+++ b/nonebot_plugin_maimaidx/libraries/tool.py
@@ -1,4 +1,6 @@
 import time
+import aiofiles
+from pathlib import Path
 
 
 def hash(qq: int):
@@ -18,3 +20,9 @@ def render_forward_msg(msg_list: list, uid: int=10001, name: str='maimaiDX'):
             }
         })
     return forward_msg
+
+
+async def read_image(file: Path) -> bytes:
+    async with aiofiles.open(file, 'rb') as f:
+        img = await f.read()
+    return img


### PR DESCRIPTION
和上一次发送帮助图片失败是同一个错误
在使用MuMu模拟器运行OpenShamrock并在宿主机运行nonebot的情况下File URI是不可使用的，因为OpenShamrock读取不了nonebot回传的路径