### PR TITLE
修复随个 指令部分问题

### DIFF
--- a/nonebot_plugin_maimaidx/command/mai_base.py
+++ b/nonebot_plugin_maimaidx/command/mai_base.py
@@ -108,7 +108,7 @@ async def _(match = RegexMatched()):
         if match.group(2) == '':
             music_data = mai.total_list.filter(level=level, type=tp)
         else:
-            music_data = mai.total_list.filter(level=level, diff=['绿黄红紫白'.index(match[1])], type=tp)
+            music_data = mai.total_list.filter(level=level, diff=['绿黄红紫白'.index(match.group(2))], type=tp)
         if len(music_data) == 0:
             msg = '没有这样的乐曲哦。'
         else:


### PR DESCRIPTION
修改部分异常情况
如
来个黄10
Traceback (most recent call last):
    music_data = mai.total_list.filter(level=level, diff=['绿黄红紫白'.index(match[1])], type=tp)
TypeError: must be str, not NoneType
出现如上问题，
在python3.8和3.11都是NoneType，需要改成match[2]可以正常获取'黄'字
不知道是不是因为版本问题，所以直接改成了group(2)
修改后重新测试
来个dx黄8
来个sd黄10
来个黄10
均正常响应