### PR TITLE
修改 随个的正则表达式

### DIFF
--- a/nonebot_plugin_maimaidx/command/mai_base.py
+++ b/nonebot_plugin_maimaidx/command/mai_base.py
@@ -15,7 +15,7 @@ maimaidxrepo    = on_command('项目地址maimaiDX', aliases={'项目地址maima
 update_data     = on_command('更新maimai数据', permission=SUPERUSER, priority=5)
 mai_today       = on_command('今日mai', aliases={'今日舞萌', '今日运势'}, priority=5)
 mai_what        = on_regex(r'.*mai.*什么(.+)?', priority=5)
-random_song     = on_regex(r'^[随来给]个((?:dx|sd|标准))?([绿黄红紫白]?)([0-9]+\+?)$', priority=5)
+random_song     = on_regex(r'^[随来给]个((?:dx|sd|标准))?([绿黄红紫白]?)([0-9]+\+?).*', priority=5)
 rating_ranking  = on_command('查看排名', aliases={'查看排行'}, priority=5)
 
 


### PR DESCRIPTION
在使用的时候有些人喜欢发
随个13+陪我睡觉
之类的，原来的正则表达式会不匹配，改了下让后面不管加什么都无所谓

修改后测试：
随个红10陪我睡觉
随个13+
随个紫13+
随个dx紫13+ qwq

均正常响应，但是不是bug或者问题，只是匹配上的改变
只是希望可以这么调整下