### PR TITLE
修复了煌/星/宙 版本查询"xx进度"的情况下 会直接返回已达成的问题

### DIFF
--- a/nonebot_plugin_maimaidx/config.py
+++ b/nonebot_plugin_maimaidx/config.py
@@ -89,11 +89,11 @@ plate_to_version: Dict[str, str] = {
     '華': 'maimai でらっくす PLUS',
     '华': 'maimai でらっくす PLUS',
     '爽': 'maimai でらっくす Splash',
-    '煌': 'maimai でらっくす Splash PLUS',
+    '煌': 'maimai でらっくす Splash',
     '宙': 'maimai でらっくす UNiVERSE',
-    '星': 'maimai でらっくす UNiVERSE PLUS',
+    '星': 'maimai でらっくす UNiVERSE',
     '祭': 'maimai でらっくす FESTiVAL',
-    '祝': 'maimai でらっくす FESTiVAL PLUS',
+    '祝': 'maimai でらっくす FESTiVAL',
     '双': 'maimai でらっくす BUDDiES'
 }
 platecn = {


### PR DESCRIPTION
修复了 由于水鱼查分器乐曲数据同步国服版本 原有的如`Splash PLUS`版本也同样视作`Splash`版本

导致无法查询到煌/星/宙 版本牌子进度剩余曲目的问题

![image](https://github.com/user-attachments/assets/11e65158-b090-4091-b0dc-b37d2bdad205)
