### PR TITLE
fix: 修复多个指令的崩溃与逻辑错误

### DIFF
--- a/nonebot_plugin_maimaidx/commands/depend.py
+++ b/nonebot_plugin_maimaidx/commands/depend.py
@@ -75,6 +75,14 @@ GetUserAndAuthOrNone = GetUserModel(auto_create=True, check_auth=True, check_ski
 """获取用户数据，若不存在则创建，并检查是否授权，未授权则返回`None`"""
 
 
+def _isfloat(value: str) -> bool:
+    try:
+        float(value)
+        return True
+    except ValueError:
+        return False
+
+
 async def process_regex(
     matcher: Matcher, match: Match[str] = RegexMatched()
 ) -> tuple[list[Song], int]:
@@ -91,24 +99,26 @@ async def process_regex(
     page = 1
     match cmd:
         case None:
-            match a_list:
-                case [name]:
-                    title = name
-                case [name, p_raw]:
-                    title, page = name, int(p_raw)
-                case _:
-                    await matcher.finish(
-                        "没有找到这样的乐曲。\n※ 如果是别名请使用「XXX是什么歌」指令进行查询哦。",
-                        reply_message=True,
-                    )
+            if not a_list:
+                await matcher.finish(
+                    "没有找到这样的乐曲。\n※ 如果是别名请使用「XXX是什么歌」指令进行查询哦。",
+                    reply_message=True,
+                )
+            # 末尾为纯数字时视为页数，其余整体作为标题（支持含空格的标题）
+            if len(a_list) >= 2 and a_list[-1].isdigit():
+                title, page = " ".join(a_list[:-1]), int(a_list[-1])
+            else:
+                title = " ".join(a_list)
             result = mai.total_list.filter(title=title)
         case "定数":
             match a_list:
-                case [ds]:
+                case [ds] if _isfloat(ds):
                     ds1 = ds2 = float(ds)
-                case [ds1_raw, ds2_raw]:
+                case [ds1_raw, ds2_raw] if _isfloat(ds1_raw) and _isfloat(ds2_raw):
                     ds1, ds2 = float(ds1_raw), float(ds2_raw)
-                case [ds1_raw, ds2_raw, p_raw]:
+                case [ds1_raw, ds2_raw, p_raw] if (
+                    _isfloat(ds1_raw) and _isfloat(ds2_raw) and p_raw.isdigit()
+                ):
                     ds1, ds2, page = float(ds1_raw), float(ds2_raw), int(p_raw)
                 case _:
                     await matcher.finish(
@@ -122,15 +132,17 @@ async def process_regex(
             result = mai.total_list.filter(level_value=(ds1, ds2))
         case "bpm":
             match a_list:
-                case [bpm_raw]:
+                case [bpm_raw] if _isfloat(bpm_raw):
                     result = mai.total_list.filter(bpm=float(bpm_raw))
-                case [b1, b2]:
+                case [b1, b2] if _isfloat(b1) and _isfloat(b2):
                     if float(b1) > float(b2):
-                        page = int(b2)
+                        page = int(float(b2))
                         result = mai.total_list.filter(bpm=float(b1))
                     else:
                         result = mai.total_list.filter(bpm=(float(b1), float(b2)))
-                case [b1, b2, p_raw]:
+                case [b1, b2, p_raw] if (
+                    _isfloat(b1) and _isfloat(b2) and p_raw.isdigit()
+                ):
                     result = mai.total_list.filter(bpm=(float(b1), float(b2)))
                     page = int(p_raw)
                 case _:
@@ -143,19 +155,19 @@ async def process_regex(
                         reply_message=True,
                     )
         case "曲师" | "谱师":
-            match a_list:
-                case [name]:
-                    pass
-                case [name, p_raw] if p_raw.isdigit():
-                    page = int(p_raw)
-                case _:
-                    await matcher.finish(
-                        (
-                            f"{cmd}查歌参数错误，请输入正确格式，页数为可选：\n"
-                            f"{cmd}查歌「{cmd}」「页数」"
-                        ),
-                        reply_message=True,
-                    )
+            if not a_list:
+                await matcher.finish(
+                    (
+                        f"{cmd}查歌参数错误，请输入正确格式，页数为可选：\n"
+                        f"{cmd}查歌「{cmd}」「页数」"
+                    ),
+                    reply_message=True,
+                )
+            # 末尾为纯数字时视为页数，其余整体作为曲师/谱师名（支持含空格的名字）
+            if len(a_list) >= 2 and a_list[-1].isdigit():
+                name, page = " ".join(a_list[:-1]), int(a_list[-1])
+            else:
+                name = " ".join(a_list)
             if cmd == "曲师":
                 result = mai.total_list.filter(artist=name)
             else:

--- a/nonebot_plugin_maimaidx/commands/depend.py
+++ b/nonebot_plugin_maimaidx/commands/depend.py
@@ -75,7 +75,7 @@ GetUserAndAuthOrNone = GetUserModel(auto_create=True, check_auth=True, check_ski
 """获取用户数据，若不存在则创建，并检查是否授权，未授权则返回`None`"""
 
 
-def _isfloat(value: str) -> bool:
+def is_float(value: str) -> bool:
     try:
         float(value)
         return True
@@ -112,12 +112,12 @@ async def process_regex(
             result = mai.total_list.filter(title=title)
         case "定数":
             match a_list:
-                case [ds] if _isfloat(ds):
+                case [ds] if is_float(ds):
                     ds1 = ds2 = float(ds)
-                case [ds1_raw, ds2_raw] if _isfloat(ds1_raw) and _isfloat(ds2_raw):
+                case [ds1_raw, ds2_raw] if is_float(ds1_raw) and is_float(ds2_raw):
                     ds1, ds2 = float(ds1_raw), float(ds2_raw)
                 case [ds1_raw, ds2_raw, p_raw] if (
-                    _isfloat(ds1_raw) and _isfloat(ds2_raw) and p_raw.isdigit()
+                    is_float(ds1_raw) and is_float(ds2_raw) and p_raw.isdigit()
                 ):
                     ds1, ds2, page = float(ds1_raw), float(ds2_raw), int(p_raw)
                 case _:
@@ -132,16 +132,16 @@ async def process_regex(
             result = mai.total_list.filter(level_value=(ds1, ds2))
         case "bpm":
             match a_list:
-                case [bpm_raw] if _isfloat(bpm_raw):
+                case [bpm_raw] if is_float(bpm_raw):
                     result = mai.total_list.filter(bpm=float(bpm_raw))
-                case [b1, b2] if _isfloat(b1) and _isfloat(b2):
+                case [b1, b2] if is_float(b1) and is_float(b2):
                     if float(b1) > float(b2):
                         page = int(float(b2))
                         result = mai.total_list.filter(bpm=float(b1))
                     else:
                         result = mai.total_list.filter(bpm=(float(b1), float(b2)))
                 case [b1, b2, p_raw] if (
-                    _isfloat(b1) and _isfloat(b2) and p_raw.isdigit()
+                    is_float(b1) and is_float(b2) and p_raw.isdigit()
                 ):
                     result = mai.total_list.filter(bpm=(float(b1), float(b2)))
                     page = int(p_raw)

--- a/nonebot_plugin_maimaidx/commands/mai_alias.py
+++ b/nonebot_plugin_maimaidx/commands/mai_alias.py
@@ -31,10 +31,10 @@ alias_apply = on_command(
 alias_agree = on_command("同意别名", aliases={"同意别称"})
 alias_status = on_command("当前投票", aliases={"当前别名投票", "当前别称投票"})
 alias_switch = on_regex(
-    r"^([开启关闭]+)别名推送$", permission=SUPERUSER | GROUP_OWNER | GROUP_ADMIN
+    r"^(开启|关闭)别名推送$", permission=SUPERUSER | GROUP_OWNER | GROUP_ADMIN
 )
-alias_global_switch = on_regex(r"^全局([开启关闭]+)别名推送$", permission=SUPERUSER)
-alias_song = on_regex(r"^(id)?\s?(.+)\s?有什么别[名称]$", re.IGNORECASE)
+alias_global_switch = on_regex(r"^全局(开启|关闭)别名推送$", permission=SUPERUSER)
+alias_song = on_regex(r"^(id(?=[\s0-9]))?\s?(.+)\s?有什么别[名称]$", re.IGNORECASE)
 
 
 @update_alias.handle()
@@ -117,9 +117,11 @@ async def _(event: GroupMessageEvent, message: Message = CommandArg()):
         tag = message.extract_plain_text().strip().upper()
         api = YuzuChaNAPI()
         status = await api.post_agree_user(tag, event.user_id)
-        await alias_agree.finish(status.message, reply_message=True)
-    except ValueError as e:
-        await alias_agree.finish(str(e), reply_message=True)
+        msg = status.message
+    except Exception as e:
+        log.error(traceback.format_exc())
+        msg = str(e)
+    await alias_agree.finish(msg, reply_message=True)
 
 
 @alias_status.handle()
@@ -131,7 +133,8 @@ async def _(message: Message = CommandArg()):
         if not status:
             await alias_status.finish("未查询到正在进行的别名投票", reply_message=True)
 
-        page = max(min(int(args), len(status) // SONGS_PER_PAGE + 1), 1) if args else 1
+        total_pages = (len(status) + SONGS_PER_PAGE - 1) // SONGS_PER_PAGE
+        page = max(min(int(args), total_pages), 1) if args.isdigit() else 1
         result = []
         for num, _s in enumerate(status):
             if (page - 1) * SONGS_PER_PAGE <= num < page * SONGS_PER_PAGE:
@@ -146,7 +149,7 @@ async def _(message: Message = CommandArg()):
                         - 票数：{_s.agree_votes}/{_s.votes}
                     """)
                 )
-        result.append(f"第「{page}」页，共「{len(status) // SONGS_PER_PAGE + 1}」页")
+        result.append(f"第「{page}」页，共「{total_pages}」页")
         msg = MessageSegment.image(text_to_bytes_io("\n".join(result)))
     except Exception as e:
         log.error(traceback.format_exc())
@@ -195,11 +198,14 @@ async def _(match: Match[str] = RegexMatched()):
             reply_message=True,
         )
 
-    if len(aliases[0].alias) == 1:
+    real_aliases = [
+        a for a in aliases[0].alias if a.lower() != aliases[0].song_name.lower()
+    ]
+    if not real_aliases:
         await alias_song.finish("该曲目没有别名", reply_message=True)
 
     msg = f"该曲目有以下别名：\nID：{aliases[0].song_id}\n"
-    msg += "\n".join(aliases[0].alias)
+    msg += "\n".join(real_aliases)
     await alias_song.send(msg, reply_message=True)
 
 

--- a/nonebot_plugin_maimaidx/commands/mai_base.py
+++ b/nonebot_plugin_maimaidx/commands/mai_base.py
@@ -206,7 +206,7 @@ async def _(
 ):
     if not match:
         await random_song.finish("参数错误，请重新发送随机谱面", reply_message=True)
-    diff = match.group(1)
+    diff = (match.group(1) or "").lower()
     if diff == "dx":
         type_ = ["DX"]
     elif diff == "sd" or diff == "标准":
@@ -214,10 +214,15 @@ async def _(
     else:
         type_ = ["SD", "DX"]
     level = match.group(3)
-    if match.group(2) == "":
-        songs = mai.total_list.filter(level=level, type=type_)
-    else:
-        songs = mai.total_list.filter(level=level, type=type_)
+    color = match.group(2)
+    songs = mai.total_list.filter(level=level, type=type_)
+    if color:
+        ci = "绿黄红紫白".index(color)
+        songs = [
+            s
+            for s in songs
+            if len(s.difficulties) > ci and s.difficulties[ci].level == level
+        ]
     if len(songs) == 0:
         result = "没有这样的乐曲哦。"
     else:
@@ -265,3 +270,6 @@ async def _(user: User = Depends(GetOrCreateUser)):
         if rank.username == info.username:
             result = f"您的Rating为「{rank.ra}」，排名第「{num + 1}」名"
             await my_rating_ranking.finish(result, reply_message=True)
+    await my_rating_ranking.finish(
+        "未在查分器排行榜中找到您的记录。", reply_message=True
+    )

--- a/nonebot_plugin_maimaidx/commands/mai_score.py
+++ b/nonebot_plugin_maimaidx/commands/mai_score.py
@@ -60,6 +60,8 @@ async def _(
         else:
             song_id = aliases[0].song_id
         song = mai.total_list.by_id(song_id)
+        if song is None:
+            await info.finish("未找到曲目", reply_message=True)
 
     result = await draw_play_data(user, song)
     await info.send(result, reply_message=True)
@@ -93,11 +95,10 @@ async def _(message: Message = CommandArg()):
             await ginfo.finish(msg.strip(), reply_message=True)
         else:
             song = mai.total_list.by_id(alias[0].song_id)
-    stats = song.difficulties[level_index].stats
-
-    if len(song.difficulties) == 4 and level_index == 4:
+    if level_index >= len(song.difficulties):
         await ginfo.finish("该乐曲没有这个等级", reply_message=True)
-    if not song.difficulties[level_index]:
+    stats = song.difficulties[level_index].stats
+    if stats is None:
         await ginfo.finish("该等级没有统计信息", reply_message=True)
 
     data = await draw_song_galobal_data(song, level_index) + dedent(f"""\
@@ -140,6 +141,8 @@ async def _(message: Message = CommandArg()):
             chart_id = int(result.group(2))
             line = float(args[-1])
             song = mai.total_list.by_id(chart_id)
+            if song is None or level_index >= len(song.difficulties):
+                raise ValueError
             chart = song.difficulties[level_index]
             tap = int(chart.notes.tap)
             slide = int(chart.notes.slide)

--- a/nonebot_plugin_maimaidx/commands/mai_search.py
+++ b/nonebot_plugin_maimaidx/commands/mai_search.py
@@ -95,7 +95,7 @@ async def _(
         await search_alias_song.finish(
             "您要找的是不是：" + await draw_chart_info(song, user), reply_message=True
         )
-    if search_id := re.search(r"^id([0-9]*)$", name, re.IGNORECASE):
+    if search_id := re.search(r"^id([0-9]+)$", name, re.IGNORECASE):
         song = mai.total_list.by_id(int(search_id.group(1)))
         if not song:
             await search_alias_song.finish(

--- a/nonebot_plugin_maimaidx/commands/mai_table.py
+++ b/nonebot_plugin_maimaidx/commands/mai_table.py
@@ -30,7 +30,7 @@ TABLE_PATTERN = (
     r"([極极将舞神者]舞?){}表?\s?([0-9]+)?$"
 )
 LEVEL_PATTERN = r"^([0-9]+\+?)\s?((?:a+|b+|c|d|s+|ap|fc|fs|fdx)\+?)\s?([\u4e00-\u9fa5]+)?\s?进度\s?([0-9]+)?$"
-LEVEL_LIST_PATTERN = r"([0-9]+\.?[0-9]?\+?)\s?分数列表\s?([0-9]+)?$"
+LEVEL_LIST_PATTERN = r"^([0-9]+(?:\.[0-9]+)?\+?)\s?分数列表\s?([0-9]+)?$"
 CATEGORY_ALIAS = {
     "已完成": Category.COMPLETED,
     "未完成": Category.UNFINISHED,
@@ -87,6 +87,11 @@ async def _(match: Match[str] = RegexMatched(), user: User = Depends(GetUserAndA
     if ra in LEVEL_LIST[:6]:
         await rating_table_pfm.finish("只支持查询lv7-15的完成表。", reply_message=True)
     elif ra in LEVEL_LIST[6:]:
+        if plan and plan.lower() not in COMBO_PLUS:
+            await rating_table_pfm.finish(
+                "完成表目前仅支持「fc」「ap」计划，例如「13fc完成表」「13ap完成表」。",
+                reply_message=True,
+            )
         pic = await draw_rating_table(
             user, ra, True if plan and plan.lower() in COMBO_PLUS else False
         )
@@ -167,14 +172,15 @@ async def _(match: Match[str] = RegexMatched(), user: User = Depends(GetUserAndA
         )
     rating = match.group(1)
     page = match.group(2) or 1
-    try:
-        if "." in rating:
-            rating = round(float(rating), 1)
-        elif rating not in LEVEL_LIST:
-            await level_score_list.finish("无此等级。", reply_message=True)
-    except ValueError:
-        if rating not in LEVEL_LIST:
-            await level_score_list.finish("无此等级。", reply_message=True)
+    if "." in rating:
+        # 定数仅有一位小数，多位小数视为输入有误
+        if not re.fullmatch(r"[0-9]+\.[0-9]", rating):
+            await level_score_list.finish(
+                "输入有误，定数仅有一位小数。", reply_message=True
+            )
+        rating = round(float(rating), 1)
+    elif rating not in LEVEL_LIST:
+        await level_score_list.finish("无此等级。", reply_message=True)
 
     result = await draw_level_score_list(user, rating, int(page))
     await level_score_list.send(result, reply_message=True)

--- a/nonebot_plugin_maimaidx/core/handler.py
+++ b/nonebot_plugin_maimaidx/core/handler.py
@@ -281,7 +281,7 @@ def get_rise_score_list(
                     level_value=diff.level_value,
                     old_rating=old_result.rating,
                     old_achievements=old_result.achievements,
-                    old_rate=old_result.rate.value,
+                    old_rate=old_result.rate.value if old_result.rate else "D",
                 )
                 rise_result.append(rise)
                 break
@@ -417,9 +417,9 @@ async def get_mai_what(user: User) -> Song | None:
     if _ra != 0:
         ds = round(_ra / 22.4, 1)
         music_list = mai.total_list.filter(level_value=(ds, ds + 1))
-        for _m in music_list:
-            if int(_m.song_id) in ignore:
-                music_list.remove(_m)
+        music_list = [m for m in music_list if int(m.song_id) not in ignore]
+        if not music_list:
+            return None
         return random.choice(music_list)
     return None
 
@@ -629,8 +629,11 @@ async def draw_level_progress(
         if plan_type == 2:  # Sync
             if not res.fs:
                 return False
-            sync_list = SYNC_D_SP if res.fs in SYNC_D_SP else SYNC_SP
-            return sync_list.index(res.fs) >= plan_value
+            if res.fs in SYNC_D_SP:
+                return SYNC_D_SP.index(res.fs) >= plan_value
+            if res.fs in SYNC_SP:
+                return SYNC_SP.index(res.fs) >= plan_value
+            return False
         return False
 
     completed: list[PlayedResult] = []
@@ -656,8 +659,14 @@ async def draw_level_progress(
                 )
 
     sort_key = {0: "achievements", 1: "fc", 2: "fs"}.get(plan_type, "achievements")
-    completed.sort(key=lambda x: getattr(x, sort_key) or "", reverse=True)
-    unfinished.sort(key=lambda x: getattr(x, sort_key) or "", reverse=True)
+    sort_default = 0 if plan_type == 0 else ""
+
+    def _sort_value(res: PlayedResult):
+        value = getattr(res, sort_key)
+        return value if value is not None else sort_default
+
+    completed.sort(key=_sort_value, reverse=True)
+    unfinished.sort(key=_sort_value, reverse=True)
     notplayed.sort(key=lambda x: x.level_value, reverse=True)
 
     if category == Category.DEFAULT:
@@ -677,9 +686,8 @@ async def draw_level_progress(
     elif category in [Category.COMPLETED, Category.UNFINISHED]:
         data = completed if category == Category.COMPLETED else unfinished
         per_page = 80
-        total_page = (len(data) - 1) // per_page + 1
-        if page > total_page:
-            page = total_page
+        total_page = max(1, (len(data) - 1) // per_page + 1)
+        page = max(1, min(page, total_page))
 
         display_data = data[(page - 1) * per_page : page * per_page]
         y_size = get_rows(len(display_data), 5) * 109
@@ -728,9 +736,8 @@ async def draw_level_score_list(
     )
 
     result_sum = len(new_play_result)
-    end_page = (result_sum + 79) // 80
-    if page > end_page:
-        page = end_page
+    end_page = max(1, (result_sum + 79) // 80)
+    page = max(1, min(page, end_page))
 
     to_page = 80 if page < end_page else (result_sum % 80 or 80)
     line = (to_page + 4) // 5

--- a/nonebot_plugin_maimaidx/core/service/__init__.py
+++ b/nonebot_plugin_maimaidx/core/service/__init__.py
@@ -10,6 +10,7 @@ from ..image.tools import image_to_base64, song_chart
 from ..merge import merge_alias_data, merge_music_data
 from ..merge.alias_list import AliasList
 from ..merge.models import (
+    Alias,
     AliasesPush,
     GuessDefaultData,
     GuessPicData,
@@ -230,8 +231,9 @@ class Guess:
         """猜曲绘数据"""
         song = random.choice(self.guess_data)
         pic = self.pic(song)
-        answer = mai.total_alias_list.by_id(song.song_id)[0].alias
-        answer.append(song.song_id)
+        _alias = mai.total_alias_list.by_id(song.song_id)
+        answer = list(_alias[0].alias) if _alias else []
+        answer.append(str(song.song_id))
         return GuessPicData(
             song=song, img=image_to_base64(pic), answer=answer, end=False
         )
@@ -252,8 +254,9 @@ class Guess:
             ],
             6,
         )
-        answer = mai.total_alias_list.by_id(song.song_id)[0].alias
-        answer.append(song.song_id)
+        _alias = mai.total_alias_list.by_id(song.song_id)
+        answer = list(_alias[0].alias) if _alias else []
+        answer.append(str(song.song_id))
         pic = self.pic(song)
         return GuessDefaultData(
             song=song,
@@ -300,11 +303,24 @@ async def update_local_alias(song_id: int, alias_name: str) -> bool:
         if local_alias_file.exists():
             local_alias_data = await openfile(local_alias_file)
 
-        if song_id not in local_alias_data:
+        if song_id_key not in local_alias_data:
             local_alias_data[song_id_key] = []
+        if alias not in local_alias_data[song_id_key]:
+            local_alias_data[song_id_key].append(alias)
 
-        local_alias_data[song_id_key].append(alias)
-        mai.total_alias_list.by_id(song_id)[0].alias.append(alias)
+        entries = mai.total_alias_list.by_id(song_id)
+        if entries:
+            if alias not in entries[0].alias:
+                entries[0].alias.append(alias)
+        else:
+            _song = mai.total_list.by_id(song_id)
+            mai.total_alias_list.root.append(
+                Alias(
+                    song_id=song_id,
+                    song_name=_song.song_name if _song else "",
+                    alias=[alias],
+                )
+            )
 
         await writefile(local_alias_file, local_alias_data)
         return True


### PR DESCRIPTION
审查并修复了若干指令中的崩溃与逻辑错误，均不改变正常路径行为，仅补齐异常/边界处理。

### 崩溃 / 无响应
- **猜歌 / 猜曲绘**：`answer` 追加的是 `int` 类型 `song_id`，而 `GuessBase.answer` 为 `list[str]`，pydantic v2 默认不做 int→str 转换，构造模型即抛 `ValidationError`，功能完全不可用。改为追加 `str(song.song_id)`；同时复制别名列表避免污染 `mai.total_alias_list` 全局缓存，并对 `by_id` 空表做保护。
- **查歌 / 定数查歌 / bpm查歌 / 曲师查歌 / 谱师查歌**：对用户输入直接 `int()/float()` 未校验，`查歌 Love You` 之类含空格标题会因 `int('You')` 抛未捕获 `ValueError`（无回复）。改为校验数字、末位数字才当页数，其余整体作标题/曲师/谱师名（支持空格）。
- **id是什么歌**：`^id([0-9]*)$` 让裸 `id` 以空组匹配，`int('')` 崩溃。改为 `[0-9]+`。
- **ginfo**：`song.difficulties[level_index]` 在越界检查之前执行，4 难度曲查「白」即 `IndexError`；空 stats 守卫判断的是恒真的模型而非 `.stats`。改为先越界检查、再正确判断 `stats is None`。
- **分数线**：难度越界（如对 4 难度曲查「白」）`IndexError` 不在捕获范围。补充判断走友好提示。
- **等级进度**：`sync` 判定不在 `SYNC_*` 列表中导致 `.index()` 抛 `ValueError`；`0%` 成绩经 `or ""` 变字符串与 float 混排抛 `TypeError`。均已修正。
- **开启/关闭别名推送**：`[开启关闭]+` 字符类会匹配「启」「开关」等，落入 `else: raise ValueError`。收紧为 `(开启|关闭)`。
- **同意别名**：仅 `except ValueError`，服务端/网络异常逃逸。改为捕获并提示。

### 逻辑 / 输出错误
- **随机谱面**：大写 `DX/SD` 因大小写比较失效；颜色（绿黄红紫白）筛选两分支相同形同虚设。已规范化大小写并真正按难度颜色筛选。
- **完成表**：正则宣称支持 `s/fs/fdx` 但实际只有 `fc/ap` 生效，其余被静默忽略。改为对不支持的计划明确提示。
- **添加本地别名**：`int` 与 JSON `str` 键比较恒为真，导致每次新增都清空旧别名；对无别名曲新增首个别名 `IndexError`。已修正键类型并补充无条目时的创建。
- **info**：别名指向的曲目不存在时给出泛化「未知错误」，改为「未找到曲目」。
- **XXX有什么别名**：`(id)?` 会吞掉以「id」开头的曲名（如 `idol`、`Idoratrize World`）。改为仅当其后为空格/数字时才作 ID 标志；并过滤与标题同名的伪别名。
- **我的排名**：未上榜时静默无回复，已补提示。
- **mai什么（推分）**：遍历中 `remove` 会跳过相邻元素，空列表返回 `None` 由调用方兜底。
- **我要上分**：旧成绩 `rate` 为 `None` 时 `.value` 崩溃，回退为 `"D"`。

### 边界
- **分数列表 / 等级进度**：空结果时分页出现 `0/0` 与负数页脚，已钳制为合法范围。
- **当前投票**：页数为页大小整数倍时多算一页，已用向上取整修正。
