### PR TITLE
fix: 修复段位图片偏移（真初段及以上段位图片错位）

### DIFF
--- a/nonebot_plugin_maimaidx/core/image/best50.py
+++ b/nonebot_plugin_maimaidx/core/image/best50.py
@@ -98,10 +98,10 @@ class PlayerBest50(ScoreBaseImage):
         logo = Image.open(self.logo).resize((249, 120))
         name = Image.open(pic_dir / "Name.png")
         _cr = self.player.course_rank
-        _num = f'{_cr if _cr <= 10 else _cr + 1:02d}'
-        matchlevel = Image.open(
-            pic_dir / f'UI_DNM_DaniPlate_{_num}.png'
-        ).resize((80, 32))
+        _num = f"{_cr if _cr <= 10 else _cr + 1:02d}"
+        matchlevel = Image.open(pic_dir / f"UI_DNM_DaniPlate_{_num}.png").resize(
+            (80, 32)
+        )
         classlevel = Image.open(
             pic_dir / f"UI_FBR_Class_{self.player.class_rank:02d}.png"
         ).resize((90, 54))

--- a/nonebot_plugin_maimaidx/core/image/best50.py
+++ b/nonebot_plugin_maimaidx/core/image/best50.py
@@ -97,8 +97,10 @@ class PlayerBest50(ScoreBaseImage):
         """
         logo = Image.open(self.logo).resize((249, 120))
         name = Image.open(pic_dir / "Name.png")
+        _cr = self.player.course_rank
+        _num = f'{_cr if _cr <= 10 else _cr + 1:02d}'
         matchlevel = Image.open(
-            pic_dir / f"UI_DNM_DaniPlate_{self.player.course_rank:02d}.png"
+            pic_dir / f'UI_DNM_DaniPlate_{_num}.png'
         ).resize((80, 32))
         classlevel = Image.open(
             pic_dir / f"UI_FBR_Class_{self.player.class_rank:02d}.png"


### PR DESCRIPTION
## 问题

`additional_rating` 从 11（真初段）开始，对应的资源文件 `UI_DNM_DaniPlate_11.png` 并非真初段图片。v2.1.11 的 `_findMatchLevel()` 中存在 `+1` 偏移逻辑（`addRating > 10` 时 `num = addRating + 1`），v3.0.0 重构后丢失。

## 对比

| 段位 | addRating | 正确文件 | v3.0.9 错误指向 |
|------|----------|---------|---------------|
| 十段 | 10 | DaniPlate_10.png ✅ | DaniPlate_10.png ✅ |
| 真初段 | 11 | DaniPlate_**12**.png | DaniPlate_**11**.png ❌ |
| 真二段 | 12 | DaniPlate_**13**.png | DaniPlate_**12**.png ❌ |

## 参考

v2.1.11 commit 617d3f2 `libraries/maimaidx_best_50.py` `_findMatchLevel()` 方法：
```python
if self.addRating <= 10:
    num = f'{self.addRating:02d}'
else:
    num = f'{self.addRating + 1:02d}'
return f'UI_DNM_DaniPlate_{num}.png'
```