### PR TITLE
Feature/divingfish oauth

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,10 @@
    ASSETS_ONLINE=true                   # 对于有 `icon` 和 `plate` 资源的可将此项改为 `false`，如果没有请默认，否则使用落雪查分器时无法使用
 
    # diving-fish                        # 水鱼查分器配置
-   DIVINGFISH_TOKEN=                    # 开发者 token，由于水鱼查分器修改了请求鉴权，未填写的仅可使用 `b50` 指令
+   DIVINGFISH_CLIENT_ID=                # OAuth 应用ID，向水鱼申请应用后获得
+   DIVINGFISH_CLIENT_SECRET=            # OAuth 应用秘钥
+   DIVINGFISH_AUTH_URL=                 # 水鱼账号地址，默认 https://auth.diving-fish.com，一般不需要填
+   DIVINGFISH_TOKEN=                    # 开发者 token，已弃用，见下方说明
    DIVINGFISH_PROBER_PROXY=false        # 是否使用中转访问水鱼查分器，适用于境外服务器
 
    # lxns                               # 落雪查分器配置，均未填写将无法使用落雪查分器
@@ -108,6 +111,12 @@
    REDIRECT_URI=                        # OAuth 回调地址
    LXNS_BIND_PRIVATE_ONLY=false         # 是否仅允许私聊完成 OAuth 绑定，默认允许群聊和私聊
    ```
+
+> [!NOTE]
+> 使用水鱼 OAuth 绑定时，用户发送 `dfbind`（或「绑定水鱼」），BOT 会返回一条授权链接，用户打开并确认页面上显示的绑定身份后点击「同意授权」即可，**不需要把授权码回贴给 BOT**。绑定关系与授权范围保存在水鱼服务端，BOT 只保管应用凭据，不保存任何用户令牌；用户可随时在 https://auth.diving-fish.com/apps 撤销授权。未绑定的用户仍可使用 `b50` 指令。
+
+> [!WARNING]
+> `DIVINGFISH_TOKEN`（开发者 token）已被水鱼查分器弃用：它能按 QQ 号读取任意用户的成绩，用户从未对 BOT 做过授权，也无法撤销。水鱼已停止签发新的开发者 token，并将在过渡期后关闭该鉴权方式。请改为申请 OAuth 应用并配置 `DIVINGFISH_CLIENT_ID` 与 `DIVINGFISH_CLIENT_SECRET`。两者同时配置时优先使用 OAuth 授权。
 
 > [!NOTE]
 > 使用落雪 OAuth 绑定时，可在群聊或私聊发送 `lxbind`，按提示完成授权后发送授权码或完整回调链接；群聊发起的绑定也可以转到同一 Bot 的私聊完成。若设置 `LXNS_BIND_PRIVATE_ONLY=true`，群聊只会提示用户添加 Bot 好友后前往私聊。部分 OneBot 实现无法接收陌生人的私聊消息，因此该选项默认关闭。

--- a/nonebot_plugin_maimaidx/__init__.py
+++ b/nonebot_plugin_maimaidx/__init__.py
@@ -60,9 +60,22 @@ async def get_music():
     log.success("猜歌数据初始化完成")
     log.success("maimai数据获取完成")
 
-    if dfconfig.divingfish_token is None:
+    if dfconfig.oauth_enabled:
+        log.opt(colors=True).info(
+            "水鱼查分器已启用「<g>OAuth 授权</g>」，用户需使用「绑定水鱼」指令授权"
+        )
+        if dfconfig.divingfish_token:
+            log.opt(colors=True).warning(
+                "<y>已配置水鱼开发者Token，OAuth 授权优先，该配置项可以移除</y>"
+            )
+    elif dfconfig.divingfish_token:
         log.opt(colors=True).warning(
-            "<r>未配置水鱼查分器开发者Token，查分模块只能使用「b50」指令</r>"
+            "<y>水鱼开发者Token 已弃用，将在过渡期后停止工作，"
+            "请配置 DIVINGFISH_CLIENT_ID 与 DIVINGFISH_CLIENT_SECRET 改用 OAuth 授权</y>"
+        )
+    else:
+        log.opt(colors=True).warning(
+            "<r>未配置水鱼查分器 OAuth 应用，查分模块只能使用「b50」指令</r>"
         )
     if lxnsconfig.lxns_dev_token is None:
         log.opt(colors=True).warning(

--- a/nonebot_plugin_maimaidx/commands/mai_base.py
+++ b/nonebot_plugin_maimaidx/commands/mai_base.py
@@ -18,12 +18,14 @@ from PIL import Image
 from pydantic import ValidationError
 from sqlalchemy.exc import SQLAlchemyError
 
-from ..config import log, lxnsconfig, maiconfig
+from ..config import dfconfig, log, lxnsconfig, maiconfig
 from ..constants import FORTUNE, LEVEL_LIST
 from ..core.clients.divingfish.client import DivingFishAPI
+from ..core.clients.divingfish.oauth import REVOKE_URL, binding_label
 from ..core.clients.exceptions import HTTPError, UnknownError
 from ..core.database.qq import User, update_user
 from ..core.handler import (
+    bind_divingfish,
     bind_lxns,
     draw_chart_info,
     draw_rating_ranking,
@@ -69,6 +71,22 @@ AUTHORIZE_MSG = dedent(f"""
     「隐私设置」开启允许读取成绩，否
     则BOT将无法查询您的成绩
 """).strip()
+DIVINGFISH_AUTHORIZE_MSG = dedent("""
+    请完成水鱼查分器授权：
+
+    1. 打开以下链接并登录水鱼账号
+    =======================
+    {url}
+    =======================
+    2. 确认页面显示的绑定身份为「{label}」后点击「同意授权」
+
+    链接 {minutes} 分钟内有效，授权完成后直接使用查询指令即可，无需回复授权码。
+    =======================
+    请注意！！这条链接仅供您本人使用，请勿转发他人。
+    如需取消授权，请前往 {revoke}
+""").strip()
+DIVINGFISH_OAUTH_ERROR = "BOT管理员尚未配置水鱼查分器 OAuth 应用，无法进行绑定授权。"
+DIVINGFISH_BIND_FAILED_MSG = "发起水鱼授权失败：水鱼账号服务可能暂时不可用，请稍后再试。"
 LXNS_ERROR = "BOT管理员尚未配置落雪查分器相关信息"
 GROUP_BIND_GUIDE = (
     "BOT 管理员已将落雪绑定设置为仅私聊。\n"
@@ -121,6 +139,7 @@ update_data = on_command("更新maimai数据", permission=SUPERUSER)
 help = on_command("帮助maimaiDX", aliases={"帮助maimaidx"})
 maimaidxrepo = on_command("项目地址maimaiDX", aliases={"项目地址maimaidx"})
 bind = on_command("lxbind", aliases={"绑定落雪", "绑定lx"}, block=True)
+df_bind = on_command("dfbind", aliases={"绑定水鱼", "绑定df"}, block=True)
 bind_code = on_message(
     rule=is_type(GroupMessageEvent, PrivateMessageEvent)
     & Rule(is_pending_authorization_code),
@@ -223,6 +242,28 @@ async def _(
     if succeeded:
         pending_bindings.consume(event.self_id, event.user_id)
     await bind_code.finish(result, reply_message=True)
+
+
+@df_bind.handle()
+async def _(user: User = Depends(GetOrCreateSender)):
+    if not dfconfig.oauth_enabled:
+        await df_bind.finish(DIVINGFISH_OAUTH_ERROR, reply_message=True)
+
+    try:
+        authorization = await bind_divingfish(user.qqid)
+    except (HTTPError, HTTPXError, UnknownError, ValidationError) as error:
+        log.warning(f"水鱼授权发起失败：{type(error).__name__}")
+        await df_bind.finish(DIVINGFISH_BIND_FAILED_MSG, reply_message=True)
+
+    await df_bind.finish(
+        DIVINGFISH_AUTHORIZE_MSG.format(
+            url=authorization.verification_uri_complete,
+            label=binding_label(user.qqid),
+            minutes=max(authorization.expires_in // 60, 1),
+            revoke=dfconfig.divingfish_auth_url.rstrip("/") + REVOKE_URL,
+        ),
+        reply_message=True,
+    )
 
 
 @source.handle()

--- a/nonebot_plugin_maimaidx/config.py
+++ b/nonebot_plugin_maimaidx/config.py
@@ -19,6 +19,15 @@ class BaseConfig(BaseModel):
 class DivingFishConfig(BaseModel):
     divingfish_prober_proxy: bool = False
     divingfish_token: str | None = None
+    """开发者 token，已弃用，水鱼查分器将停止签发并在过渡期后关闭该鉴权方式，
+    请改用 `divingfish_client_id` 与 `divingfish_client_secret`"""
+    divingfish_client_id: str | None = None
+    divingfish_client_secret: str | None = None
+    divingfish_auth_url: str = "https://auth.diving-fish.com"
+
+    @property
+    def oauth_enabled(self) -> bool:
+        return bool(self.divingfish_client_id and self.divingfish_client_secret)
 
 
 class LxnsConfig(BaseModel):

--- a/nonebot_plugin_maimaidx/core/clients/divingfish/client.py
+++ b/nonebot_plugin_maimaidx/core/clients/divingfish/client.py
@@ -4,13 +4,16 @@ from ....config import dfconfig
 from ..exceptions import UnknownError, UserNotExistsError
 from ..http import ApiClient
 from .exceptions import (
+    DivingFishNotAuthorizedError,
     DivingFishTokenDisableError,
     DivingFishTokenError,
     DivingFishTokenNotFoundError,
+    DivingFishTooManyRequestsError,
     DivingFishUserDisabledQueryError,
     DivingFishUserNotFoundError,
 )
 from .models import PlayInfoDefault, PlayInfoDev, UserInfo, UserInfoDev, UserRanking
+from .oauth import get_access_token
 
 
 class DivingFishAPI(ApiClient):
@@ -18,26 +21,36 @@ class DivingFishAPI(ApiClient):
     base_url = "https://maimai.diving-fish.com/api/maimaidxprober"
 
     def __init__(self, qqid: int | None = None, username: str | None = None):
+        #: 授权模式下查谁由令牌决定，请求里不再携带 `qq`，也不需要开发者 token
+        self.oauth = dfconfig.oauth_enabled and qqid is not None and username is None
         super().__init__(
             base_url=self.base_url,
-            headers={"developer-token": dfconfig.divingfish_token}
-            if dfconfig.divingfish_token
-            else None,
+            headers=None
+            if self.oauth or not dfconfig.divingfish_token
+            else {"developer-token": dfconfig.divingfish_token},
         )
+        self.qqid = qqid
+        self._retried = False
         self.json = {}
         if qqid:
             self.json["qq"] = qqid
         if username:
             self.json["username"] = username
-            del self.json["qq"]
+            self.json.pop("qq", None)
 
     def _handle_error(self, resp: Response):
         if resp.status_code == 200:
             return
         if resp.status_code == 400:
             self._handle_400(resp.json())
+        elif resp.status_code == 401:
+            raise DivingFishTokenError
         elif resp.status_code == 403:
+            if self.oauth:
+                raise DivingFishNotAuthorizedError
             raise DivingFishUserDisabledQueryError
+        elif resp.status_code == 429:
+            raise DivingFishTooManyRequestsError
         else:
             raise UnknownError
 
@@ -61,6 +74,21 @@ class DivingFishAPI(ApiClient):
 
     async def _request_data(self, method: str, endpoint: str, **kwargs) -> dict | list:
         return await self._request(method, endpoint, **kwargs)
+
+    async def _request_oauth(self, method: str, endpoint: str, **kwargs) -> dict | list:
+        """代用户请求，令牌由水鱼账号按用户的授权范围签发"""
+        self.headers["Authorization"] = f"Bearer {await get_access_token(self.qqid)}"
+        return await self._request(method, endpoint, **kwargs)
+
+    async def _on_unauthorized(self) -> bool:
+        """令牌过期，重新换取一次"""
+        if not self.oauth or self._retried:
+            return False
+        self._retried = True
+        self.headers["Authorization"] = (
+            f"Bearer {await get_access_token(self.qqid, refresh=True)}"
+        )
+        return True
 
     @classmethod
     def set_proxy(cls) -> None:
@@ -94,40 +122,54 @@ class DivingFishAPI(ApiClient):
         Returns:
             `List[PlayInfoDefault]` 数据列表
         """
-        self.json["version"] = version
-
-        result = await self._request_data("POST", "/query/plate", json=self.json)
+        if self.oauth:
+            result = await self._request_oauth(
+                "POST", "/player/plate", json={"version": version}
+            )
+        else:
+            self.json["version"] = version
+            result = await self._request_data("POST", "/query/plate", json=self.json)
 
         return [PlayInfoDefault.model_validate(d) for d in result["verlist"]]
 
-    async def query_user_get_dev(self) -> UserInfoDev:
+    async def query_user_records(self) -> UserInfoDev:
         """
-        使用开发者接口获取用户数据，请确保拥有和输入了开发者 `token`
+        获取用户所有成绩
 
         Returns:
-            `UserInfoDev` 开发者用户信息
+            `UserInfoDev` 用户信息
         """
-        result = await self._request_data(
-            "GET", "/dev/player/records", params=self.json
-        )
+        if self.oauth:
+            result = await self._request_oauth("GET", "/player/records")
+        else:
+            result = await self._request_data(
+                "GET", "/dev/player/records", params=self.json
+            )
         return UserInfoDev.model_validate(result)
 
-    async def query_user_post_dev(
+    async def query_user_record(
         self, *, song_id: str | int | list[str | int]
     ) -> list[PlayInfoDev]:
         """
-        使用开发者接口获取用户指定曲目数据，请确保拥有和输入了开发者 `token`
+        获取用户指定曲目成绩
 
         Params:
             `song_id`: 曲目id，可以为单个ID或者列表
         Returns:
-            `List[PlayInfoDev]` 开发者成绩列表
+            `List[PlayInfoDev]` 成绩列表
         """
         if not isinstance(song_id, list):
             song_id = [song_id]
-        self.json["music_id"] = song_id
 
-        result = await self._request_data("POST", "/dev/player/record", json=self.json)
+        if self.oauth:
+            result = await self._request_oauth(
+                "POST", "/player/record", json={"music_id": song_id}
+            )
+        else:
+            self.json["music_id"] = song_id
+            result = await self._request_data(
+                "POST", "/dev/player/record", json=self.json
+            )
         if result == {}:
             return []
 

--- a/nonebot_plugin_maimaidx/core/clients/divingfish/client.py
+++ b/nonebot_plugin_maimaidx/core/clients/divingfish/client.py
@@ -22,7 +22,7 @@ class DivingFishAPI(ApiClient):
 
     def __init__(self, qqid: int | None = None, username: str | None = None):
         #: 授权模式下查谁由令牌决定，请求里不再携带 `qq`，也不需要开发者 token
-        self.oauth = dfconfig.oauth_enabled and qqid is not None and username is None
+        self.oauth = dfconfig.oauth_enabled and qqid is not None and not username
         super().__init__(
             base_url=self.base_url,
             headers=None

--- a/nonebot_plugin_maimaidx/core/clients/divingfish/client.py
+++ b/nonebot_plugin_maimaidx/core/clients/divingfish/client.py
@@ -19,7 +19,7 @@ class DivingFishAPI(ApiClient):
 
     def __init__(self, qqid: int | None = None, username: str | None = None):
         super().__init__(
-            base_url="https://maimai.diving-fish.com/api/maimaidxprober",
+            base_url=self.base_url,
             headers={"developer-token": dfconfig.divingfish_token}
             if dfconfig.divingfish_token
             else None,
@@ -63,8 +63,8 @@ class DivingFishAPI(ApiClient):
         return await self._request(method, endpoint, **kwargs)
 
     @classmethod
-    def set_proxy(self) -> None:
-        self.base_url = self.proxy_url + "/maimaidxprober"
+    def set_proxy(cls) -> None:
+        cls.base_url = cls.proxy_url + "/maimaidxprober"
 
     async def music_data(self) -> list:
         """获取曲目数据"""

--- a/nonebot_plugin_maimaidx/core/clients/divingfish/exceptions.py
+++ b/nonebot_plugin_maimaidx/core/clients/divingfish/exceptions.py
@@ -19,3 +19,15 @@ class DivingFishTokenNotFoundError(HTTPError):
 
 class DivingFishTokenError(TokenError):
     """Token错误"""
+
+
+class DivingFishNotAuthorizedError(PlayerDataError):
+    """用户未授权BOT访问水鱼查分器数据"""
+
+
+class DivingFishTooManyRequestsError(HTTPError):
+    """请求次数超出配额"""
+
+
+class DivingFishOAuthError(HTTPError):
+    """水鱼查分器 OAuth 请求失败"""

--- a/nonebot_plugin_maimaidx/core/clients/divingfish/models/__init__.py
+++ b/nonebot_plugin_maimaidx/core/clients/divingfish/models/__init__.py
@@ -6,6 +6,10 @@ from .music import (
     Notes2,
     Stats,
 )
+from .oauth import (
+    AccessToken,
+    DeviceAuthorization,
+)
 from .score import (
     ChartInfo,
     Charts,
@@ -22,8 +26,10 @@ from .score import (
 )
 
 __all__ = [
+    "AccessToken",
     "BasicInfo",
     "Chart",
+    "DeviceAuthorization",
     "Music",
     "Notes1",
     "Notes2",

--- a/nonebot_plugin_maimaidx/core/clients/divingfish/models/oauth.py
+++ b/nonebot_plugin_maimaidx/core/clients/divingfish/models/oauth.py
@@ -1,0 +1,21 @@
+from pydantic import BaseModel
+
+
+class DeviceAuthorization(BaseModel):
+    """发起绑定后水鱼账号返回的授权信息"""
+
+    device_code: str
+    user_code: str
+    verification_uri: str
+    verification_uri_complete: str
+    expires_in: int
+    interval: int = 5
+
+
+class AccessToken(BaseModel):
+    """代用户访问的令牌，没有 `refresh_token`，过期后重新换取"""
+
+    access_token: str
+    token_type: str
+    expires_in: int
+    scope: str

--- a/nonebot_plugin_maimaidx/core/clients/divingfish/oauth.py
+++ b/nonebot_plugin_maimaidx/core/clients/divingfish/oauth.py
@@ -1,0 +1,146 @@
+"""水鱼查分器 OAuth。
+
+BOT 只保管 `client_id` 与 `client_secret`，不保存任何用户令牌：
+
+1. 用户发送「绑定水鱼」，BOT 换取一个 `user_code` 并把授权链接发给用户；
+2. 用户在水鱼账号页面确认授权，绑定关系与授权范围都记录在水鱼服务端；
+3. 之后每次查询，BOT 用应用凭据换取该用户 5 分钟有效的 `access_token`。
+
+用户标识只以 `sha256("<client_id>:<QQ号>")` 的形式发送，水鱼服务端存的也是
+这个摘要，因此 QQ 号不会离开 BOT。
+"""
+
+from hashlib import sha256
+from time import monotonic
+
+from httpx import Response
+
+from ....config import dfconfig
+from ..http import ApiClient
+from .exceptions import (
+    DivingFishNotAuthorizedError,
+    DivingFishOAuthError,
+    DivingFishTokenNotFoundError,
+)
+from .models import AccessToken, DeviceAuthorization
+
+DEVICE_CODE_GRANT = "urn:ietf:params:oauth:grant-type:device_code"
+ON_BEHALF_OF_GRANT = "urn:diving-fish:params:oauth:grant-type:on-behalf-of"
+SCOPE = "prober.records.read"
+REVOKE_URL = "/apps"
+
+#: 提前一点过期，避免令牌在请求途中失效
+EXPIRES_MARGIN = 30
+
+
+def subject_ref(qqid: int) -> str:
+    """用户标识摘要，水鱼服务端用它定位授权过的账号"""
+    return sha256(f"{dfconfig.divingfish_client_id}:{qqid}".encode()).hexdigest()
+
+
+def binding_label(qqid: int) -> str:
+    """展示在授权页面上的绑定身份，用户凭它确认不是在给别人授权"""
+    qq = str(qqid)
+    if len(qq) <= 4:
+        return f"QQ {qq}"
+    return f"QQ {qq[:2]}{'*' * (len(qq) - 4)}{qq[-2:]}"
+
+
+class TokenCache:
+    def __init__(self) -> None:
+        self._tokens: dict[str, tuple[str, float]] = {}
+
+    def get(self, ref: str) -> str | None:
+        cached = self._tokens.get(ref)
+        if cached is None:
+            return None
+        token, expires_at = cached
+        if expires_at <= monotonic():
+            del self._tokens[ref]
+            return None
+        return token
+
+    def set(self, ref: str, token: AccessToken) -> None:
+        expires_at = monotonic() + max(token.expires_in - EXPIRES_MARGIN, 0)
+        self._tokens[ref] = (token.access_token, expires_at)
+
+    def discard(self, ref: str) -> None:
+        self._tokens.pop(ref, None)
+
+
+tokens = TokenCache()
+
+
+class DivingFishOAuth(ApiClient):
+    def __init__(self):
+        super().__init__(base_url=dfconfig.divingfish_auth_url.rstrip("/"))
+        self.client_id = dfconfig.divingfish_client_id
+        self.client_secret = dfconfig.divingfish_client_secret
+
+    async def device_authorization(self, qqid: int) -> DeviceAuthorization:
+        """发起绑定，返回给用户点开的授权链接
+
+        顺带丢掉缓存的令牌：绑定到另一个账号后，旧令牌仍会在缓存里存活到过期，
+        那段时间查出来的还是上一个账号的成绩
+        """
+        tokens.discard(subject_ref(qqid))
+        data = {
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
+            "scope": SCOPE,
+            "subject_ref": subject_ref(qqid),
+            "binding_label": binding_label(qqid),
+        }
+        result = await self._request_data(
+            "POST", "/oauth/device_authorization", data=data
+        )
+        return DeviceAuthorization.model_validate(result)
+
+    async def fetch_token(self, qqid: int) -> AccessToken:
+        """换取代该用户访问的令牌"""
+        data = {
+            "grant_type": ON_BEHALF_OF_GRANT,
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
+            "subject": f"ref:{subject_ref(qqid)}",
+            "scope": SCOPE,
+        }
+        result = await self._request_data("POST", "/oauth/token", data=data)
+        return AccessToken.model_validate(result)
+
+    async def _request_data(self, method: str, endpoint: str, **kwargs) -> dict:
+        return await self._request(method, endpoint, **kwargs)
+
+    def _handle_error(self, resp: Response) -> None:
+        if resp.status_code == 200:
+            return
+        if not dfconfig.oauth_enabled:
+            raise DivingFishTokenNotFoundError
+
+        error = ""
+        try:
+            error = resp.json().get("error", "")
+        except ValueError:
+            pass
+
+        if error == "consent_required":
+            raise DivingFishNotAuthorizedError
+        raise DivingFishOAuthError
+
+
+async def get_access_token(qqid: int, *, refresh: bool = False) -> str:
+    """取该用户的令牌，命中缓存则直接复用
+
+    Params:
+        `qqid`: 用户QQ
+        `refresh`: 丢弃缓存重新换取
+    """
+    ref = subject_ref(qqid)
+    if refresh:
+        tokens.discard(ref)
+    elif token := tokens.get(ref):
+        return token
+
+    result = await DivingFishOAuth().fetch_token(qqid)
+    tokens.set(ref, result)
+    return result.access_token

--- a/nonebot_plugin_maimaidx/core/handler.py
+++ b/nonebot_plugin_maimaidx/core/handler.py
@@ -170,7 +170,7 @@ async def get_player_result(
         if version is not None:
             data = await api.query_user_plate(version)
         else:
-            result = await api.query_user_get_dev()
+            result = await api.query_user_records()
             data = result.records
         play_result = df_to_playresult(data)
     elif user.service == ServiceName.LXNS:
@@ -369,7 +369,7 @@ async def draw_play_data(user: User, song: Song) -> MessageSegment:
     """
     if user.service == ServiceName.DIVINGFISH:
         api = DivingFishAPI(qqid=user.qqid)
-        data = await api.query_user_post_dev(song_id=song.song_id)
+        data = await api.query_user_record(song_id=song.song_id)
         if not data:
             raise MusicNotPlayError
 

--- a/nonebot_plugin_maimaidx/core/handler.py
+++ b/nonebot_plugin_maimaidx/core/handler.py
@@ -18,6 +18,8 @@ from ..constants import (
     VERSION_MAP,
 )
 from .clients.divingfish.client import DivingFishAPI
+from .clients.divingfish.models import DeviceAuthorization
+from .clients.divingfish.oauth import DivingFishOAuth
 from .clients.exceptions import MusicNotPlayError, NotMusicRecommendationError
 from .clients.lxns.client import LxnsAPI, OAuth2
 from .clients.lxns.models import BaseToken, OAuth2Token, SongType
@@ -118,6 +120,18 @@ async def bind_lxns(user: User, code: str) -> str:
     else:
         result = "授权完成。"
     return result
+
+
+async def bind_divingfish(qqid: int) -> DeviceAuthorization:
+    """
+    发起水鱼查分器绑定，返回给用户点开的授权信息
+
+    Params:
+        `qqid`: 用户QQ
+    Returns:
+        `DeviceAuthorization`
+    """
+    return await DivingFishOAuth().device_authorization(qqid)
 
 
 async def get_best50(

--- a/nonebot_plugin_maimaidx/core/handler_error.py
+++ b/nonebot_plugin_maimaidx/core/handler_error.py
@@ -6,9 +6,12 @@ from nonebot.adapters.onebot.v11 import MessageSegment
 
 from ..config import log
 from .clients.divingfish.exceptions import (
+    DivingFishNotAuthorizedError,
+    DivingFishOAuthError,
     DivingFishTokenDisableError,
     DivingFishTokenError,
     DivingFishTokenNotFoundError,
+    DivingFishTooManyRequestsError,
     DivingFishUserDisabledQueryError,
     DivingFishUserNotFoundError,
 )
@@ -26,6 +29,11 @@ from .clients.lxns.exceptions import (
     LXNSTooManyRequestsError,
 )
 
+NOTAUTHORIZED = dedent("""
+    您尚未授权本 BOT 访问您的水鱼查分器成绩，或已取消授权。
+    请发送「绑定水鱼」，按提示完成授权后再试。
+""").strip()
+
 NOTFOUNDUSER = dedent("""
     未在水鱼查分器找到此玩家，请确保此玩家的用户名和查分器中的用户名相同。
     如未绑定，请前往查分器官网进行绑定。
@@ -40,6 +48,13 @@ def handle_errors(func):
             return await func(*args, **kwargs)
 
         ### DivingFish
+        except DivingFishNotAuthorizedError:
+            return MessageSegment.text(NOTAUTHORIZED)
+        except DivingFishTooManyRequestsError:
+            return MessageSegment.text("水鱼查分器请求次数已达上限，请稍后再试。")
+        except DivingFishOAuthError:
+            log.error("水鱼账号服务请求失败。")
+            return MessageSegment.text("水鱼账号服务暂时不可用，请稍后再试。")
         except DivingFishUserNotFoundError:
             return MessageSegment.text(NOTFOUNDUSER)
         except UserNotExistsError:


### PR DESCRIPTION
## 这个 PR 做了什么

水鱼查分器弃用了开发者 token，改为 OAuth 授权：第三方应用不再持有能按 QQ 号读取任意用户成绩的万能凭据，而是由用户本人授权后，应用凭 `client_id` / `client_secret` 换取代该用户访问的短期令牌。

开发者 token 的问题在于用户从未参与过授权，也无法撤销；水鱼已停止签发新的开发者 token，并会在过渡期后关闭该鉴权方式。这个 PR 让插件支持新的授权路线，同时**保留原有开发者 token 路线不变**，未配置 OAuth 应用的部署不受影响。

## 新增配置

```
DIVINGFISH_CLIENT_ID=        # OAuth 应用ID，向水鱼申请应用后获得
DIVINGFISH_CLIENT_SECRET=    # OAuth 应用秘钥
DIVINGFISH_AUTH_URL=         # 水鱼账号地址，默认 https://auth.diving-fish.com，一般不需要填
```

`DIVINGFISH_CLIENT_ID` 与 `DIVINGFISH_CLIENT_SECRET` 同时配置时启用授权路线；与 `DIVINGFISH_TOKEN` 同时存在时优先使用授权路线，并在启动时提示 token 可以移除。

## 绑定流程

用户发送 `dfbind`（别名「绑定水鱼」「绑定df」），BOT 返回一条授权链接：

1. 用户打开链接、登录水鱼账号；
2. 页面上会显示这次绑定的身份（如 `QQ 23******78`）和应用申请的权限，用户确认后点「同意授权」；
3. 完成，直接用查询指令即可。

**不需要把授权码回贴给 BOT**（走的是 RFC 8628 设备授权，没有回调地址）。绑定关系与授权范围保存在水鱼服务端，用户可随时在 <https://auth.diving-fish.com/apps> 撤销。未绑定的用户仍可使用 `b50` 指令。

## 实现要点

- **BOT 不保存任何用户令牌。** 每次查询用应用凭据换取一个 5 分钟有效的 `access_token`，进程内按用户缓存到过期，401 时自动重换一次（有重试保护，不会递归）。
- **QQ 号不离开 BOT。** 用户标识只以 `sha256("<client_id>:<QQ号>")` 的摘要形式发送，水鱼服务端存的也是这个摘要，且摘要按应用加盐，不同应用之间无法对撞。
- **授权模式下的端点**（请求里不再携带 `qq`，查谁由令牌决定，返回范围由用户的授权范围决定）：

  | 授权模式 | 原开发者接口 |
  | --- | --- |
  | `GET /player/records` | `GET /dev/player/records` |
  | `POST /player/record` | `POST /dev/player/record` |
  | `POST /player/plate` | `POST /query/plate` |

  响应结构与原接口一致，因此模型和绘图逻辑没有改动。开发者接口的两个方法按新端点重命名为 `query_user_records` / `query_user_record`。

- 新增错误提示：未授权（引导用户发送「绑定水鱼」）、配额超限、水鱼账号服务不可用。

## 顺带修了一个不相关的 bug

`fix(divingfish): set_proxy 对已创建的实例不生效` —— `DivingFishAPI.__init__` 把 `base_url` 写成了字面量，而 `set_proxy()` 改的是类属性，所以 `DIVINGFISH_PROBER_PROXY=true` 时实例仍然直连查分器。这个 commit 可以单独 review / cherry-pick。

## 测试情况

在实际 NoneBot 部署上跑过：`绑定水鱼` → 授权 → `b50`、`minfo`、`分数线`、完成表相关指令均正常；未授权用户会收到引导绑定的提示；撤销授权后再查询同样回到该提示。

## 需要 maintainer 帮忙的地方

- `maimaidxhelp.png` 里没有加上 `绑定水鱼`，因为没有图片的设计源文件，麻烦在合并时补一下。
