### PR TITLE
fix: 修复相同等级谱面的 chart stats 错位

### DIFF
--- a/nonebot_plugin_maimaidx/core/merge/__init__.py
+++ b/nonebot_plugin_maimaidx/core/merge/__init__.py
@@ -217,11 +217,8 @@ async def merge_music_data(
         if song is None:
             continue
 
-        for s in stat_list:
-            for diff in song.difficulties:
-                if diff.level == s.diff:
-                    diff.stats = s
-                    break
+        for diff, stat in zip(song.difficulties, stat_list):
+            diff.stats = stat
 
     result = MusicList(root=song_map.values())
     await writefile(merge_music_file, result.model_dump())


### PR DESCRIPTION
## 问题表现

在查询部分谱面数据时，出现拟合难度和水鱼数据对不上的情况。以谱面 Endless World 为例：

<img width="600" height="650" alt="728ce628aee78221fbb06278479efede" src="https://github.com/user-attachments/assets/4b18096a-2811-42a0-8b8b-d39dd39c37ea" />

图中显示 Master 难度的拟合定数为 13.11，Re:Master 难度的拟合定数未显示；而水鱼的数据显示，Master 难度的拟合定数应为 13.52，Re:Master 难度的拟合定数应为 13.11。

## 问题原因

追溯到合并谱面数据的相关代码：

<https://github.com/Yuri-YuzuChaN/nonebot-plugin-maimaidx/blob/6d43291cdead4326e6fc3191cfeb764c52f70988/nonebot_plugin_maimaidx/core/merge/__init__.py#L215-L224>

日志打印对应谱面的 `stat_list` 和 `song.difficulties`（仅保留相关字段）：

```python3
stat_list = [
    Stats(diff="5", fit_diff=4.9991),
    Stats(diff="7", fit_diff=7.0017),
    Stats(diff="11", fit_diff=11.4782),
    Stats(diff="13", fit_diff=13.5170),  # Master
    Stats(diff="13", fit_diff=13.1091),  # Re:Master
]

song.difficulties = [
    Difficulties(level_index=LevelIndex.BASIC, level="5", stats=Stats(diff="5", fit_diff=4.9991)),
    Difficulties(level_index=LevelIndex.ADVANCED, level="7", stats=Stats(diff="7", fit_diff=7.0017)),
    Difficulties(level_index=LevelIndex.EXPERT, level="11", stats=Stats(diff="11", fit_diff=11.4782)),
    Difficulties(level_index=LevelIndex.MASTER, level="13", stats=Stats(diff="13", fit_diff=13.1091)),
    Difficulties(level_index=LevelIndex.RE_MASTER, level="13", stats=None),
]
```

可以发现，无论是 `diff.level` 还是 `stat.diff`，都只是粗略分级，因此不能作为区分不同难度的标记。当同一首歌存在多个相同 level 的谱面时，每次都只会匹配到第一个符合条件的谱面。

本例中 Master 谱面和 Re:Master 谱面的难度均被标记为 13，因此会出现如下合并操作：

```
Master.stats = Master stats
Master.stats = Re:Master stats
Re:Master.stats = None
```

即前一个谱面的统计数据被覆盖，而后一个谱面的统计数据没有被正确赋值。

## 修复方案

水鱼提供的 `chart_stats` 本身不提供难度相关的标记，但已经按难度顺序组织，在代码库中的数据路径大致为：

```
Diving-Fish /chart_stats
→ HTTP JSON
→ get_music_list()
→ Stats.model_validate()
→ stats_map
→ merge_music_data()
```

检查上述路径后，可以确认谱面统计列表的顺序在传递过程中没有被重新排序或打乱，因此可以直接按顺序合并 `chart_stats`，详细代码见 commit。

修复后的显示情况如下：

<img width="600" height="650" alt="e4daae622ed1cfe3f77addbff13bdc3c" src="https://github.com/user-attachments/assets/20e311f9-3f2d-4ba5-a8af-7839ac37edf0" />

