### PR TITLE
fix: 修复上分推荐功能中 old_rate 未被 RANK_MAP 映射的问题

### DIFF
--- a/nonebot_plugin_maimaidx/core/image/score.py
+++ b/nonebot_plugin_maimaidx/core/image/score.py
@@ -88,7 +88,7 @@ class DrawScore(ScoreBaseImage):
             )
             if _d.old_rate:
                 oldrate = Image.open(
-                    self._pic_theme_path / f"UI_TTR_Rank_{_d.old_rate}.png"
+                    self._pic_theme_path / f"UI_TTR_Rank_{RANK_MAP[_d.old_rate]}.png"
                 ).resize((63, 28))
                 self._im.alpha_composite(oldrate, (x + 145, y + 82))
             self._im.alpha_composite(rate, (x + 305, y + 82))


### PR DESCRIPTION
```
08-26 17:08:41 [ERROR] nonebot_plugin_maimaidx | 发生错误: Traceback (most recent call last):
  File "/root/sotan-bot/.venv/lib/python3.13/site-packages/nonebot_plugin_maimaidx/core/handler_error.py", line 40, in wrapper
    return await func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/sotan-bot/.venv/lib/python3.13/site-packages/nonebot_plugin_maimaidx/core/handler.py", line 597, in draw_rise_score_list
    image = ds.draw_rise(sd, sd_low_score, dx, dx_low_score, 960)
  File "/root/sotan-bot/.venv/lib/python3.13/site-packages/nonebot_plugin_maimaidx/core/image/score.py", line 155, in draw_rise
    self.while_rise_pic(dx, dx_score, False)
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
  File "/root/sotan-bot/.venv/lib/python3.13/site-packages/nonebot_plugin_maimaidx/core/image/score.py", line 90, in while_rise_pic
    oldrate = Image.open(
              ~~~~~~~~~~^
        self._pic_theme_path / f"UI_TTR_Rank_{_d.old_rate}.png"
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ).resize((63, 28))
    ^
  File "/root/sotan-bot/.venv/lib/python3.13/site-packages/PIL/Image.py", line 3513, in open
    fp = builtins.open(filename, "rb")
FileNotFoundError: [Errno 2] No such file or directory: '/root/sotan-bot/sotan/static/mai/pic/prism_plus/UI_TTR_Rank_sss.png'
```

这一段：

https://github.com/Yuri-YuzuChaN/nonebot-plugin-maimaidx/blob/0eb9b243849066aa1683000e427f1686f114577e/nonebot_plugin_maimaidx/core/image/score.py#L90-L92

相比上面：

https://github.com/Yuri-YuzuChaN/nonebot-plugin-maimaidx/blob/0eb9b243849066aa1683000e427f1686f114577e/nonebot_plugin_maimaidx/core/image/score.py#L77-L79

少了 `RANK_MAP` 映射。修改后本地部署可以正常出图。