### PR TITLE
feat(divingfish): 绑定改为由用户回填确认码

### DIFF
--- a/nonebot_plugin_maimaidx/commands/mai_base.py
+++ b/nonebot_plugin_maimaidx/commands/mai_base.py
@@ -21,12 +21,18 @@ from sqlalchemy.exc import SQLAlchemyError
 from ..config import dfconfig, log, lxnsconfig, maiconfig
 from ..constants import FORTUNE, LEVEL_LIST
 from ..core.clients.divingfish.client import DivingFishAPI
+from ..core.clients.divingfish.exceptions import (
+    DivingFishBindingMismatchError,
+    DivingFishConfirmationCodeError,
+)
 from ..core.clients.divingfish.oauth import REVOKE_URL, binding_label
 from ..core.clients.exceptions import HTTPError, UnknownError
 from ..core.database.qq import User, update_user
+from ..core.divingfish_oauth import extract_confirmation_code
 from ..core.handler import (
     bind_divingfish,
     bind_lxns,
+    complete_divingfish_binding,
     draw_chart_info,
     draw_rating_ranking,
     draw_rise_score_list,
@@ -34,11 +40,11 @@ from ..core.handler import (
 )
 from ..core.image.tools import image_to_base64, song_chart
 from ..core.lxns_oauth import (
-    PendingBindingStore,
     build_authorize_url,
     extract_authorization_code,
     is_binding_channel_allowed,
 )
+from ..core.pending_binding import PendingBindingStore
 from ..core.merge.models import ServiceName, Theme
 from ..core.service import mai
 from ..core.tool import qqhash
@@ -79,8 +85,28 @@ DIVINGFISH_AUTHORIZE_MSG = dedent("""
     {url}
     =======================
     2. 确认页面显示的绑定身份为「{label}」后点击「同意授权」
+    3. 复制页面给出的确认码，回到 QQ 发送给 BOT
 
-    链接 {minutes} 分钟内有效，授权完成后直接使用查询指令即可，无需回复授权码。
+    本次绑定 {minutes} 分钟内有效，确认码只能使用一次；
+    超时或失效后请重新发送「绑定水鱼」。
+    =======================
+    请注意！！链接与确认码都仅供您本人使用，请勿转发他人。
+    确认码建议在与 BOT 的私聊中发送，避免被他人看到。
+    如需取消授权，请前往 {revoke}
+""").strip()
+#: 水鱼那侧还不认 handoff=code 时用的说明（旧版本会忽略这个参数）。
+#: 那种情况下页面不发确认码，但绑定本身照常成立：用户点完同意，
+#: 映射就建好了，下一条查询指令自然会成功
+DIVINGFISH_AUTHORIZE_LEGACY_MSG = dedent("""
+    请完成水鱼查分器授权：
+
+    1. 打开以下链接并登录水鱼账号，授权「{bot_name} BOT」访问您的水鱼查分器数据
+    =======================
+    {url}
+    =======================
+    2. 确认页面显示的绑定身份为「{label}」后点击「同意授权」
+
+    链接 {minutes} 分钟内有效，授权完成后直接使用查询指令即可，无需回复确认码。
     =======================
     请注意！！这条链接仅供您本人使用，请勿转发他人。
     如需取消授权，请前往 {revoke}
@@ -88,6 +114,33 @@ DIVINGFISH_AUTHORIZE_MSG = dedent("""
 DIVINGFISH_OAUTH_ERROR = "BOT管理员尚未配置水鱼查分器 OAuth 应用，无法进行绑定授权。"
 DIVINGFISH_BIND_FAILED_MSG = (
     "发起水鱼授权失败：水鱼账号服务可能暂时不可用，请稍后再试。"
+)
+DIVINGFISH_NO_SESSION_MSG = (
+    "请先发送「绑定水鱼」获取授权链接，完成授权后再发送确认码。"
+)
+DIVINGFISH_INVALID_CODE_MSG = (
+    "未识别到有效的水鱼确认码。\n"
+    "请发送授权完成页面显示的完整确认码，形如 BCDF-GHJK-LMNP。"
+)
+DIVINGFISH_CODE_FAILED_MSG = (
+    "水鱼绑定失败：确认码可能已使用、已过期，或不是本次绑定的确认码。\n"
+    "当前绑定会话仍有效，您可以发送新的确认码；"
+    "如需重新授权，请再次发送「绑定水鱼」。"
+)
+DIVINGFISH_MISMATCH_MSG = (
+    "水鱼绑定失败：这串确认码对应的授权不属于您的账号。\n"
+    "确认码只能由发起绑定的本人使用，请勿使用他人转发给您的确认码。\n"
+    "如需绑定自己的账号，请发送「绑定水鱼」重新走一遍授权。"
+)
+DIVINGFISH_BIND_SUCCESS_MSG = "水鱼查分器授权完成，现在可以直接使用查询指令了。"
+#: 水鱼的绑定会话要盖住两段窗口：授权链接的 10 分钟，加上用户点完同意之后
+#: 确认码自己的 10 分钟。只按前一段算的话，拖到最后一刻才点同意的人，
+#: 拿着一串仍然有效的码发回来会石沉大海——匹配器不认，BOT 一声不吭
+DIVINGFISH_SESSION_TTL = 20 * 60
+DIVINGFISH_CODE_TEMPORARY_FAILED_MSG = (
+    "水鱼绑定暂时失败：水鱼账号服务或网络出现异常。\n"
+    "当前绑定会话仍有效，您可以稍后重新发送确认码；"
+    "如果确认码已经使用，请再次发送「绑定水鱼」重新授权。"
 )
 LXNS_ERROR = "BOT管理员尚未配置落雪查分器相关信息"
 GROUP_BIND_GUIDE = (
@@ -120,9 +173,24 @@ async def is_pending_authorization_code(
         is_private=isinstance(event, PrivateMessageEvent),
     ):
         return False
-    return pending_bindings.is_active(event.self_id, event.user_id) and bool(
-        extract_authorization_code(event.get_plaintext())
-    )
+    return pending_bindings.is_active(
+        event.self_id, event.user_id, ServiceName.LXNS
+    ) and bool(extract_authorization_code(event.get_plaintext()))
+
+
+async def is_pending_confirmation_code(
+    event: GroupMessageEvent | PrivateMessageEvent,
+) -> bool:
+    """这条消息是不是「发起水鱼绑定的那个人」发回来的确认码
+
+    两个条件缺一不可：这个 QQ 此刻确实在等水鱼的码（会话按
+    `(self_id, user_id)` 记，别人发的落不到这条记录上），且整条消息
+    就是一串确认码。剩下那一半核对在
+    `handler.complete_divingfish_binding` 里向水鱼求证。
+    """
+    return pending_bindings.is_active(
+        event.self_id, event.user_id, ServiceName.DIVINGFISH
+    ) and bool(extract_confirmation_code(event.get_plaintext()))
 
 
 async def complete_lxns_binding(user: User, code: str) -> tuple[str, bool]:
@@ -145,6 +213,12 @@ df_bind = on_command("dfbind", aliases={"绑定水鱼", "绑定df"}, block=True)
 bind_code = on_message(
     rule=is_type(GroupMessageEvent, PrivateMessageEvent)
     & Rule(is_pending_authorization_code),
+    priority=0,
+    block=True,
+)
+df_bind_code = on_message(
+    rule=is_type(GroupMessageEvent, PrivateMessageEvent)
+    & Rule(is_pending_confirmation_code),
     priority=0,
     block=True,
 )
@@ -209,7 +283,7 @@ async def _(
 
     text = message.extract_plain_text().strip()
     if not text:
-        pending_bindings.start(event.self_id, event.user_id)
+        pending_bindings.start(event.self_id, event.user_id, ServiceName.LXNS)
         channel_guide = (
             "请在当前私聊发送授权码或完整回调链接。"
             if is_private
@@ -228,7 +302,7 @@ async def _(
     if succeeded:
         pending_bindings.discard(event.self_id, event.user_id)
     else:
-        pending_bindings.start(event.self_id, event.user_id)
+        pending_bindings.start(event.self_id, event.user_id, ServiceName.LXNS)
     await bind.finish(result, reply_message=True)
 
 
@@ -238,7 +312,9 @@ async def _(
     user: User = Depends(GetOrCreateSender),
 ):
     code = extract_authorization_code(event.get_plaintext())
-    if code is None or not pending_bindings.is_active(event.self_id, event.user_id):
+    if code is None or not pending_bindings.is_active(
+        event.self_id, event.user_id, ServiceName.LXNS
+    ):
         return
     result, succeeded = await complete_lxns_binding(user, code)
     if succeeded:
@@ -246,10 +322,47 @@ async def _(
     await bind_code.finish(result, reply_message=True)
 
 
+async def complete_divingfish(qqid: int, code: str) -> tuple[str, bool]:
+    try:
+        await complete_divingfish_binding(qqid, code)
+    except DivingFishBindingMismatchError:
+        # 码有效，但兑出来的授权不是这个 QQ 的。多半是把别人转发来的码
+        # 当成自己的用了——照实说清楚，别让他以为是自己操作错了
+        log.warning("水鱼确认码与发起绑定的用户不一致")
+        return DIVINGFISH_MISMATCH_MSG, False
+    except DivingFishConfirmationCodeError:
+        return DIVINGFISH_CODE_FAILED_MSG, False
+    except (HTTPError, HTTPXError, UnknownError, ValidationError) as error:
+        log.warning(f"水鱼绑定暂时失败：{type(error).__name__}")
+        return DIVINGFISH_CODE_TEMPORARY_FAILED_MSG, False
+    return DIVINGFISH_BIND_SUCCESS_MSG, True
+
+
 @df_bind.handle()
-async def _(user: User = Depends(GetOrCreateSender)):
+async def _(
+    event: GroupMessageEvent | PrivateMessageEvent,
+    message: Message = CommandArg(),
+    user: User = Depends(GetOrCreateSender),
+):
     if not dfconfig.oauth_enabled:
         await df_bind.finish(DIVINGFISH_OAUTH_ERROR, reply_message=True)
+
+    # 「绑定水鱼 BCDF-GHJK-LMNP」：把码直接跟在指令后面
+    text = message.extract_plain_text().strip()
+    if text:
+        if not pending_bindings.is_active(
+            event.self_id, event.user_id, ServiceName.DIVINGFISH
+        ):
+            # 没发起过就送来一串码，只能是别处转发来的。这时候不该去兑换：
+            # 兑换会烧掉那串码，而它本来是另一个人的
+            await df_bind.finish(DIVINGFISH_NO_SESSION_MSG, reply_message=True)
+        code = extract_confirmation_code(text)
+        if code is None:
+            await df_bind.finish(DIVINGFISH_INVALID_CODE_MSG, reply_message=True)
+        result, succeeded = await complete_divingfish(user.qqid, code)
+        if succeeded:
+            pending_bindings.consume(event.self_id, event.user_id)
+        await df_bind.finish(result, reply_message=True)
 
     try:
         authorization = await bind_divingfish(user.qqid)
@@ -257,6 +370,28 @@ async def _(user: User = Depends(GetOrCreateSender)):
         log.warning(f"水鱼授权发起失败：{type(error).__name__}")
         await df_bind.finish(DIVINGFISH_BIND_FAILED_MSG, reply_message=True)
 
+    if authorization.handoff != "code":
+        # 水鱼那侧没按确认码受理（还没上这条路），页面不会发码。等下去等不到，
+        # 但绑定本身仍然成立，所以退回老流程的说明，也不开等码的会话
+        log.warning("水鱼账号服务未以确认码方式受理本次绑定，退回原流程")
+        await df_bind.finish(
+            DIVINGFISH_AUTHORIZE_LEGACY_MSG.format(
+                bot_name=maiconfig.bot_name,
+                url=authorization.verification_uri_complete,
+                label=binding_label(user.qqid),
+                minutes=max(authorization.expires_in // 60, 1),
+                revoke=dfconfig.divingfish_auth_url.rstrip("/") + REVOKE_URL,
+            ),
+            reply_message=True,
+        )
+
+    # 会话记在这里：此后只有这个 QQ 发回来的码会被受理
+    pending_bindings.start(
+        event.self_id,
+        event.user_id,
+        ServiceName.DIVINGFISH,
+        ttl=DIVINGFISH_SESSION_TTL,
+    )
     await df_bind.finish(
         DIVINGFISH_AUTHORIZE_MSG.format(
             bot_name=maiconfig.bot_name,
@@ -267,6 +402,22 @@ async def _(user: User = Depends(GetOrCreateSender)):
         ),
         reply_message=True,
     )
+
+
+@df_bind_code.handle()
+async def _(
+    event: GroupMessageEvent | PrivateMessageEvent,
+    user: User = Depends(GetOrCreateSender),
+):
+    code = extract_confirmation_code(event.get_plaintext())
+    if code is None or not pending_bindings.is_active(
+        event.self_id, event.user_id, ServiceName.DIVINGFISH
+    ):
+        return
+    result, succeeded = await complete_divingfish(user.qqid, code)
+    if succeeded:
+        pending_bindings.consume(event.self_id, event.user_id)
+    await df_bind_code.finish(result, reply_message=True)
 
 
 @source.handle()

--- a/nonebot_plugin_maimaidx/core/clients/divingfish/exceptions.py
+++ b/nonebot_plugin_maimaidx/core/clients/divingfish/exceptions.py
@@ -31,3 +31,11 @@ class DivingFishTooManyRequestsError(HTTPError):
 
 class DivingFishOAuthError(HTTPError):
     """水鱼查分器 OAuth 请求失败"""
+
+
+class DivingFishConfirmationCodeError(HTTPError):
+    """确认码无效、已过期或已被使用"""
+
+
+class DivingFishBindingMismatchError(HTTPError):
+    """兑换出的授权不属于发起本次绑定的那个 QQ"""

--- a/nonebot_plugin_maimaidx/core/clients/divingfish/models/oauth.py
+++ b/nonebot_plugin_maimaidx/core/clients/divingfish/models/oauth.py
@@ -32,6 +32,9 @@ class DeviceAuthorization(BaseModel):
     verification_uri_complete: str
     expires_in: int
     interval: int = 5
+    #: 收尾方式。请求里带了 `handoff=code` 时水鱼会原样回显，
+    #: 借此确认本次绑定确实要等用户回填确认码
+    handoff: str = "poll"
 
 
 class AccessToken(BaseModel):
@@ -41,3 +44,5 @@ class AccessToken(BaseModel):
     token_type: str
     expires_in: int
     scope: str
+    #: 该用户的水鱼用户 ID。只有兑换确认码的响应里有，换票的响应里没有
+    sub: str | None = None

--- a/nonebot_plugin_maimaidx/core/clients/divingfish/oauth.py
+++ b/nonebot_plugin_maimaidx/core/clients/divingfish/oauth.py
@@ -2,14 +2,23 @@
 
 BOT 只保管 `client_id` 与 `client_secret`，不保存任何用户令牌：
 
-1. 用户发送「绑定水鱼」，BOT 换取一个 `user_code` 并把授权链接发给用户；
-2. 用户在水鱼账号页面确认授权，绑定关系与授权范围都记录在水鱼服务端；
-3. 之后每次查询，BOT 用应用凭据换取该用户 5 分钟有效的 `access_token`。
+1. 用户发送「绑定水鱼」，BOT 带 `handoff=code` 发起绑定，把授权链接发给用户；
+2. 用户在水鱼账号页面确认授权，页面给出一串一次性确认码；
+3. 用户把确认码发回给 BOT，BOT 凭码兑换一次令牌，绑定即告完成；
+4. 之后每次查询，BOT 用应用凭据换取该用户 5 分钟有效的 `access_token`。
+
+**第 3 步不是多余的一道手续。** 发起绑定这个动作不需要任何凭据，谁都能拿
+本 BOT 的 `client_id` 造一条绑定链接、填上自己的标识转发给别人；受害者点完
+同意，造链接的人就绑上了对方的账号。确认码只出现在点同意那个人的浏览器里，
+未经他发回来，绑定就完不成——所以这一步验的是「点同意的人」和「发起绑定的人」
+是不是同一个。BOT 这边还要再验一次，见 `handler.complete_divingfish_binding`。
 
 用户标识只以 `sha256("<client_id>:<QQ号>")` 的形式发送，水鱼服务端存的也是
 这个摘要，因此 QQ 号不会离开 BOT。
 """
 
+import json
+from base64 import urlsafe_b64decode
 from hashlib import sha256
 from time import monotonic
 
@@ -18,14 +27,16 @@ from httpx import Response
 from ....config import dfconfig
 from ..http import ApiClient
 from .exceptions import (
+    DivingFishBindingMismatchError,
+    DivingFishConfirmationCodeError,
     DivingFishNotAuthorizedError,
     DivingFishOAuthError,
     DivingFishTokenNotFoundError,
 )
 from .models import AccessToken, DeviceAuthorization
 
-DEVICE_CODE_GRANT = "urn:ietf:params:oauth:grant-type:device_code"
 ON_BEHALF_OF_GRANT = "urn:diving-fish:params:oauth:grant-type:on-behalf-of"
+CONFIRMATION_CODE_GRANT = "urn:diving-fish:params:oauth:grant-type:confirmation-code"
 REVOKE_URL = "/apps"
 
 #: 提前一点过期，避免令牌在请求途中失效
@@ -35,6 +46,21 @@ EXPIRES_MARGIN = 30
 def subject_ref(qqid: int) -> str:
     """用户标识摘要，水鱼服务端用它定位授权过的账号"""
     return sha256(f"{dfconfig.divingfish_client_id}:{qqid}".encode()).hexdigest()
+
+
+def token_subject(access_token: str) -> str | None:
+    """读出 access token 里的 `sub`（水鱼用户 ID）。
+
+    **只解不验。** 这串令牌是 BOT 刚从水鱼账号服务取回来的，用它比对
+    「兑换出的账号」和「换票换到的账号」是不是同一个，属于自洽性检查，
+    不是安全校验——真正的验签由资源服务器做。
+    """
+    try:
+        payload = access_token.split(".")[1]
+        padded = payload + "=" * (-len(payload) % 4)
+        return json.loads(urlsafe_b64decode(padded)).get("sub")
+    except (IndexError, ValueError):
+        return None
 
 
 def binding_label(qqid: int) -> str:
@@ -89,11 +115,32 @@ class DivingFishOAuth(ApiClient):
             "scope": dfconfig.divingfish_oauth_scope,
             "subject_ref": subject_ref(qqid),
             "binding_label": binding_label(qqid),
+            # 改由用户回填确认码收尾。带上它之后 device_code 换不到令牌，
+            # 这正是它的意义所在，理由见模块开头
+            "handoff": "code",
         }
         result = await self._request_data(
             "POST", "/oauth/device_authorization", data=data
         )
         return DeviceAuthorization.model_validate(result)
+
+    async def redeem(self, qqid: int, confirmation_code: str) -> AccessToken:
+        """用用户发回来的确认码兑换一次令牌
+
+        一并送上这个 QQ 的标识，让水鱼比对它和发起绑定时提交的是不是同一个，
+        也就是「回填这串码的人，是不是发起绑定的那个人」。对不上时水鱼回
+        `invalid_grant` 且**不消费这串码**——那种情况多半是用户把别人转发来
+        的码当成了自己的，烧掉它等于让码的主人从头再走一遍绑定。
+        """
+        data = {
+            "grant_type": CONFIRMATION_CODE_GRANT,
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
+            "confirmation_code": confirmation_code,
+            "subject_ref": subject_ref(qqid),
+        }
+        result = await self._request_data("POST", "/oauth/token", data=data)
+        return AccessToken.model_validate(result)
 
     async def fetch_token(self, qqid: int) -> AccessToken:
         """换取代该用户访问的令牌"""
@@ -124,6 +171,14 @@ class DivingFishOAuth(ApiClient):
 
         if error == "consent_required":
             raise DivingFishNotAuthorizedError
+        if error == "subject_mismatch":
+            # 码是真的，但不是发给这个 QQ 的——他多半把别人转发来的码
+            # 当成了自己的。水鱼在这种情况下不会消费掉那串码
+            raise DivingFishBindingMismatchError
+        if error == "invalid_grant":
+            # 码不存在、已过期、已用过、出自别的应用，水鱼一律回这一个错，
+            # 不作区分。对用户来说下一步动作都一样：重新发起一次绑定
+            raise DivingFishConfirmationCodeError
         raise DivingFishOAuthError
 
 

--- a/nonebot_plugin_maimaidx/core/divingfish_oauth.py
+++ b/nonebot_plugin_maimaidx/core/divingfish_oauth.py
@@ -1,0 +1,39 @@
+"""水鱼绑定里用户回填的那串确认码。
+
+它长得和落雪的授权码一样（`XXXX-XXXX-XXXX`），靠格式区分不开两家，所以
+「这串码该交给谁处理」由待回填会话记的服务决定，见 `pending_binding`。
+"""
+
+import re
+
+#: 水鱼的确认码只用这 20 个字母：去掉了 A/E/I/O/U（避免随机拼出脏词）
+#: 和形近的 0/1/L。用户要在聊天窗口里转发它，认错一个字符就白跑一趟
+CONFIRMATION_ALPHABET = "BCDFGHJKLMNPQRSTVWXZ"
+CONFIRMATION_CODE_LENGTH = 12
+_BODY_PATTERN = re.compile(
+    rf"^[{CONFIRMATION_ALPHABET}]{{{CONFIRMATION_CODE_LENGTH}}}$"
+)
+_PREFIX_PATTERN = re.compile(r"^(?:确认码|授权码)\s*[:：]?\s*(\S+)$")
+
+
+def extract_confirmation_code(text: str) -> str | None:
+    """从用户发来的整条消息里认出确认码，归一化成 `XXXX-XXXX-XXXX`
+
+    用户会怎么发就怎么容错：小写、连字符丢了、复制时带上「确认码：」前缀
+    或首尾空白。水鱼那边也做同一套归一化，这里再做一遍是为了在发请求之前
+    先把明显不是码的消息挡掉——这条规则要过每一条群消息。
+
+    只认「整条消息就是一串码」，不从一句话里抠。抠的话，一条正常聊天里
+    恰好凑出十二个字母就会被当成码送去兑换。
+    """
+    value = (text or "").strip()
+    prefixed = _PREFIX_PATTERN.fullmatch(value)
+    if prefixed:
+        value = prefixed.group(1)
+
+    body = re.sub(r"[\s\-—_]", "", value).upper()
+    if not _BODY_PATTERN.fullmatch(body):
+        return None
+    return "-".join(
+        body[i:i + 4] for i in range(0, CONFIRMATION_CODE_LENGTH, 4)
+    )

--- a/nonebot_plugin_maimaidx/core/handler.py
+++ b/nonebot_plugin_maimaidx/core/handler.py
@@ -18,8 +18,16 @@ from ..constants import (
     VERSION_MAP,
 )
 from .clients.divingfish.client import DivingFishAPI
+from .clients.divingfish.exceptions import (
+    DivingFishBindingMismatchError,
+    DivingFishNotAuthorizedError,
+)
 from .clients.divingfish.models import DeviceAuthorization
-from .clients.divingfish.oauth import DivingFishOAuth
+from .clients.divingfish.oauth import (
+    DivingFishOAuth,
+    get_access_token,
+    token_subject,
+)
 from .clients.exceptions import MusicNotPlayError, NotMusicRecommendationError
 from .clients.lxns.client import LxnsAPI, OAuth2
 from .clients.lxns.models import BaseToken, OAuth2Token, SongType
@@ -132,6 +140,36 @@ async def bind_divingfish(qqid: int) -> DeviceAuthorization:
         `DeviceAuthorization`
     """
     return await DivingFishOAuth().device_authorization(qqid)
+
+
+async def complete_divingfish_binding(qqid: int, code: str) -> None:
+    """
+    用用户发回来的确认码完成水鱼绑定，并核对这次绑定确实落在这个 QQ 上
+
+    「发起绑定的人」和「把码发回来的人」是不是同一个，由三道检查合起来保证：
+
+    1. `pending_binding` 的会话——码必须由发起绑定的那个 QQ 发回来，
+       别人发的连这一步都进不来；
+    2. 兑换时把这个 QQ 的标识一并送给水鱼，由它比对发起绑定时提交的那个。
+       这道是权威的，且对不上时不会消费掉那串码；
+    3. 兑换之后再用这个 QQ 换一次票，比对账号是不是同一个。
+
+    第 3 道是兜底：水鱼若还是没有第 2 道校验的版本，它就是唯一的一道。
+    换不到票，说明这个 QQ 根本没完成过授权；换到了但账号对不上，说明这个
+    QQ 早先绑过，而这次的码属于另一个人。
+
+    Params:
+        `qqid`: 用户QQ
+        `code`: 用户发回来的确认码
+    """
+    redeemed = await DivingFishOAuth().redeem(qqid, code)
+    try:
+        access_token = await get_access_token(qqid, refresh=True)
+    except DivingFishNotAuthorizedError as error:
+        raise DivingFishBindingMismatchError from error
+
+    if redeemed.sub and token_subject(access_token) != redeemed.sub:
+        raise DivingFishBindingMismatchError
 
 
 async def get_best50(

--- a/nonebot_plugin_maimaidx/core/lxns_oauth.py
+++ b/nonebot_plugin_maimaidx/core/lxns_oauth.py
@@ -1,6 +1,4 @@
 import re
-from collections.abc import Callable
-from time import monotonic
 from urllib.parse import parse_qs, urlencode, urlparse
 
 AUTHORIZATION_CODE_PATTERN = re.compile(
@@ -43,40 +41,3 @@ def extract_authorization_code(text: str) -> str | None:
             return code
 
     return None
-
-
-class PendingBindingStore:
-    def __init__(
-        self,
-        ttl: float = 10 * 60,
-        *,
-        clock: Callable[[], float] = monotonic,
-    ) -> None:
-        self.ttl = ttl
-        self._clock = clock
-        self._expires_at: dict[tuple[int, int], float] = {}
-
-    def start(self, self_id: int, user_id: int) -> None:
-        now = self._clock()
-        self._clear_expired(now)
-        self._expires_at[(self_id, user_id)] = now + self.ttl
-
-    def is_active(self, self_id: int, user_id: int) -> bool:
-        now = self._clock()
-        self._clear_expired(now)
-        return (self_id, user_id) in self._expires_at
-
-    def consume(self, self_id: int, user_id: int) -> bool:
-        now = self._clock()
-        self._clear_expired(now)
-        return self._expires_at.pop((self_id, user_id), None) is not None
-
-    def discard(self, self_id: int, user_id: int) -> None:
-        self._expires_at.pop((self_id, user_id), None)
-
-    def _clear_expired(self, now: float) -> None:
-        expired = [
-            key for key, expires_at in self._expires_at.items() if expires_at <= now
-        ]
-        for key in expired:
-            del self._expires_at[key]

--- a/nonebot_plugin_maimaidx/core/pending_binding.py
+++ b/nonebot_plugin_maimaidx/core/pending_binding.py
@@ -1,0 +1,73 @@
+"""等待用户回填授权码的会话。
+
+落雪和水鱼的绑定都是「BOT 先发起，用户再把一串码发回来」，两边都要回答
+同一个问题：**这串码是不是发起绑定的那个人发回来的**。会话按
+`(self_id, user_id)` 记，这个键本身就是那道约束——别人发的码落不到这条
+记录上，也就走不进兑换那一步。
+
+记录里同时存着是哪个服务在等码。两家的码长得一样（都是 `XXXX-XXXX-XXXX`），
+不记服务的话，水鱼的确认码会被落雪的处理器接走，反之亦然。
+
+一个用户同一时刻只保留一条：他发起新的绑定，就是不再继续上一条。
+"""
+
+from collections.abc import Callable
+from time import monotonic
+
+from .merge.models import ServiceName
+
+
+class PendingBindingStore:
+    def __init__(
+        self,
+        ttl: float = 10 * 60,
+        *,
+        clock: Callable[[], float] = monotonic,
+    ) -> None:
+        self.ttl = ttl
+        self._clock = clock
+        self._sessions: dict[tuple[int, int], tuple[ServiceName, float]] = {}
+
+    def start(
+        self,
+        self_id: int,
+        user_id: int,
+        service: ServiceName,
+        *,
+        ttl: float | None = None,
+    ) -> None:
+        """记下这个用户正在等哪一家的码
+
+        `ttl` 不填就用默认值。水鱼那条路要单独给：它的窗口是两段接起来的，
+        见 `commands.mai_base.DIVINGFISH_SESSION_TTL`。
+        """
+        now = self._clock()
+        self._clear_expired(now)
+        self._sessions[(self_id, user_id)] = (service, now + (ttl or self.ttl))
+
+    def active(self, self_id: int, user_id: int) -> ServiceName | None:
+        """这个用户此刻在等哪一家的码，没有则返回 None"""
+        now = self._clock()
+        self._clear_expired(now)
+        session = self._sessions.get((self_id, user_id))
+        return session[0] if session else None
+
+    def is_active(self, self_id: int, user_id: int, service: ServiceName) -> bool:
+        return self.active(self_id, user_id) == service
+
+    def consume(self, self_id: int, user_id: int) -> bool:
+        now = self._clock()
+        self._clear_expired(now)
+        return self._sessions.pop((self_id, user_id), None) is not None
+
+    def discard(self, self_id: int, user_id: int) -> None:
+        self._sessions.pop((self_id, user_id), None)
+
+    def _clear_expired(self, now: float) -> None:
+        expired = [
+            key
+            for key, (_, expires_at) in self._sessions.items()
+            if expires_at <= now
+        ]
+        for key in expired:
+            del self._sessions[key]


### PR DESCRIPTION
## 概述

水鱼查分器的绑定原先在用户点击同意后即告完成，BOT 侧无需后续动作。本 PR 将其改为：发起绑定时提交 `handoff=code`，用户在授权页面完成同意后得到一串一次性确认码，由其发回 BOT，BOT 凭该码换取令牌，绑定方告完成。

## 动机

水鱼账号服务的设备码端点不校验应用凭据，任何人都可以使用本插件的 `client_id` 生成一条绑定链接，填入自己的用户标识后转发给他人。受害者点击同意后，绑定即建立在链接生成者的标识上，对方可借由本 BOT 读取其成绩。原有流程中，用户能够察觉这一点的线索仅有授权页上的「绑定身份」一行。

改为回填确认码后，该码只出现在完成授权的那位用户的浏览器中。未经其本人发回，绑定无法完成。

## 一致性校验

「发起绑定」与「回填确认码」是否为同一位使用者，由三处检查共同保证：

1. 待回填会话按 `(self_id, user_id)` 记录，非发起者发送的确认码不予受理；
2. 兑换时一并提交发起绑定所用的 `subject_ref`，由水鱼账号服务比对。不一致时返回 `subject_mismatch`，且不消费该确认码，原持有者仍可正常完成绑定；
3. 兑换后再以该 QQ 换取一次令牌，比对账号是否一致。此项为兜底，用于水鱼账号服务尚未提供第 2 项校验的情形。

## 兼容性

- 无需新增或修改任何配置项。
- 若水鱼账号服务未按 `handoff=code` 受理（旧版本忽略该参数，响应中不回显 `handoff`），插件退回原有提示文案且不开启等码会话，绑定行为与本 PR 之前完全一致。
- 落雪绑定流程不受影响。`PendingBindingStore` 由 `core/lxns_oauth.py` 移至 `core/pending_binding.py`，并增加「正在等待哪一家的授权码」这一维度：两家的码格式相同（`XXXX-XXXX-XXXX`），不加区分会被彼此的处理器接走。同一使用者同一时刻只保留一条会话。

## 改动内容

- 新增 `core/pending_binding.py`：待回填会话，按 `(self_id, user_id)` 与服务记录，10 分钟过期
- 新增 `core/divingfish_oauth.py`：确认码的识别与归一化（大小写、连字符、`确认码：` 前缀、首尾空白均可容错；仅接受整条消息为一串码的情形）
- `core/clients/divingfish/oauth.py`：发起绑定提交 `handoff=code`；新增确认码兑换；新增 `DivingFishConfirmationCodeError` 与 `DivingFishBindingMismatchError`
- `core/handler.py`：新增 `complete_divingfish_binding`，负责兑换与上述第 2、3 项校验
- `commands/mai_base.py`：「绑定水鱼」支持直接附带确认码（`绑定水鱼 BCDF-GHJK-LMNP`），新增确认码消息处理器与对应提示文案

## 使用者可见的变化

「绑定水鱼」的提示由「授权完成后直接使用查询指令即可」改为三步说明，第 3 步为将页面上的确认码发回 BOT。绑定会话有效期 20 分钟，为授权链接的 10 分钟与确认码自身 10 分钟之和；仅按前者计时会导致临近超时才完成授权的使用者，其仍然有效的确认码不被受理。

## 测试

- 与水鱼账号服务在本地完成联调：发起绑定、浏览器端同意、取得确认码、兑换与校验，并覆盖「他人回填确认码被拒且不消费该码」「同一确认码不可重复兑换」「提交 `handoff=code` 后设备码轮询关闭」等分支
- 确认码识别与归一化、会话隔离（跨使用者、跨 BOT 实例、跨服务）、三处校验各分支的单元检查
- 插件加载正常
